### PR TITLE
Prefetch bye image so it can be shown on the shutdown page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <link rel="prefetch" href="/static/img/again.png" as="image">
+  <link rel="prefetch" href="/static/img/bye.png" as="image">
 </head>
 <body>
   <dpanel-app></dpanel-app>

--- a/src/index_recovery.html
+++ b/src/index_recovery.html
@@ -13,6 +13,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon_io/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon_io/favicon-16x16.png">
   <link rel="prefetch" href="/static/img/celebrate.png" as="image">
+  <link rel="prefetch" href="/static/img/bye.png" as="image">
   <link rel="manifest" href="/static/favicon_io/site.webmanifest">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 


### PR DESCRIPTION
Without this, the image is not available when it is requested.

![image](https://github.com/user-attachments/assets/5b93c8ba-3968-445b-b320-9771be9a864b)
