### PR TITLE
Don't allow setup workflow escape

### DIFF
--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -149,6 +149,11 @@ class AppModeApp extends LitElement {
       this.installationMode = installationMode;
     }
 
+    // If setup has been completed, show the DONE step
+    if (this.context.store.setupContext.isCompleted) {
+      return STEP_DONE;
+    }
+
     // If we're already fully set up, or if we've generated a key, show our login step.
     if ((hasCompletedInitialConfiguration || hasGeneratedKey) && !this.isLoggedIn) {
       return STEP_LOGIN;
@@ -194,6 +199,16 @@ class AppModeApp extends LitElement {
   _nextStep = () => {
     this.isLoggedIn = this.context.store.networkContext.token;
     this.activeStepNumber++;
+    
+    // Set setup as completed when reaching the DONE step
+    if (this.activeStepNumber === STEP_DONE) {
+      store.updateState({
+        setupContext: {
+          ...this.context.store.setupContext,
+          isCompleted: true
+        }
+      });
+    }
   };
 
   disconnectedCallback() {

--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -93,17 +93,8 @@ export class LocationPickerView extends LitElement {
   }
 
   denyClose (e) {
-    // If we're installing, prevent close.
-    if (this._inflight_install) {
-      e.preventDefault();
-    }
-
-    // If we MUST install, prevent close.
-    if (this.mode === 'mustInstall') {
-      e.preventDefault();
-    }
-
-    // Otherwise, do nothing, allow close.
+    // Always prevent install dialog from closing
+    e.preventDefault();
   }
 
   render() {

--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -12,6 +12,7 @@ import "/components/views/x-activity-log.js";
 import { getDisks, postInstallToDisk } from "/api/disks/disks.js";
 import { promptPowerOff } from "/pages/page-settings/power-helpers.js";
 import { mainChannel } from "/controllers/sockets/main-channel.js";
+import { store } from "/state/store.js";
 
 const PAGE_ONE = "intro";
 const PAGE_TWO = "disk_selection";
@@ -40,16 +41,16 @@ export class LocationPickerView extends LitElement {
     this.mode = "";
     this.open = false;
     this._ready = false;
-    this._page = PAGE_ONE;
+    this._page = store.installationContext.isCompleted ? PAGE_FOUR : PAGE_ONE;
     this._allDisks = [];
     this._installDisks = [];
     this._bootMediaDisk = null;
     this._selected_disk_index = null;
     this._confirmation_checked = false;
     this._inflight_install = false;
-    this._install_outcome = "";
+    this._install_outcome = store.installationContext.isCompleted ? "success" : "";
     this._header = "Such Install"
-    this._logs = [];
+    this._logs = store.installationContext.logs || [];
     this._unsubscribe = null;
   }
 
@@ -232,7 +233,7 @@ export class LocationPickerView extends LitElement {
   };
 
   renderInstallation = () => {
-    const selectedDisk = this._installDisks[this._selected_disk_index]
+    const selectedDisk = this._installDisks[this._selected_disk_index] || store.installationContext.selectedDisk;
     return html`
       <div class="page">
 
@@ -328,6 +329,20 @@ export class LocationPickerView extends LitElement {
     } finally {
       this._inflight_install = false;
       this._install_outcome = didErr ? "error" : "success"
+
+      if (this._install_outcome === "success") {
+              // Update store with installation completion and logs
+      store.updateState({
+        installationContext: {
+          isCompleted: true,
+          selectedDisk: {
+            name: diskName,
+            sizePretty: this._installDisks[this._selected_disk_index].sizePretty
+          },
+          logs: this._logs
+        }
+        });
+      }
     }
   }
 

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -54,6 +54,14 @@ class Store {
         hashedPassword: null,
         view: null,
       });
+    this.installationContext = {
+      isCompleted: false,
+      selectedDisk: {
+        name: null,
+        sizePretty: null
+      },
+      logs: []
+    };
 
     // Hydrate state from localStorage unless flush parameter is present.
     if (!isUnauthedRoute() && !hasFlushParam()) {
@@ -94,6 +102,7 @@ class Store {
         const savedState = JSON.parse(localStorage.getItem("storeState"));
         if (savedState) {
           this.networkContext = savedState.networkContext;
+          this.installationContext = savedState.installationContext || this.installationContext;
           // Load other slices as needed
         }
       } catch (error) {
@@ -109,6 +118,7 @@ class Store {
       try {
         const stateToPersist = {
           networkContext: this.networkContext,
+          installationContext: this.installationContext,
           // Include other slices of state as needed
         };
         localStorage.setItem("storeState", JSON.stringify(stateToPersist));
@@ -177,6 +187,12 @@ class Store {
       this.setupContext = {
         ...this.setupContext,
         ...partialState.setupContext,
+      };
+    }
+    if (partialState.installationContext) {
+      this.installationContext = {
+        ...this.installationContext,
+        ...partialState.installationContext,
       };
     }
     // Other slices..

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -51,6 +51,7 @@ class Store {
       name: null,
     }),
       (this.setupContext = {
+        isCompleted: false,
         hashedPassword: null,
         view: null,
       });


### PR DESCRIPTION
Three issues being addressed here:

1. The installation workflow dialog was escapable when 'I stay' is an option. This has been disabled to make the workflow clearer. The user must select 'I stay' or 'I choose' to progress.
2. On the installation completed step of the installation workflow, if the page is refreshed it will load the first installation step. This has been fixed by adding installationContext to the store. If installationContext.isCompleted is true, the installation completed screen will be shown on page reload. Logs and selected disk are also retained.
3. Similarly, the configuration completed 'done' step of recovery could be left on reload. setupContext.isCompleted is now set when the user completes configuration,it will direct the user to 'STEP_DONE' when true.