### PR TITLE
Handle pup source error

### DIFF
--- a/src/components/common/action-row/action-row.js
+++ b/src/components/common/action-row/action-row.js
@@ -154,7 +154,7 @@ class ActionRow extends LitElement {
       flex-direction: column;
       justify-content: center;
       border-bottom: 1px solid #333;
-      max-width: calc(100% - 80px);
+      max-width: calc(100% - 130px);
       gap: 0.25em;
 
       .label-wrap {

--- a/src/components/views/action-manage-sources/index.js
+++ b/src/components/views/action-manage-sources/index.js
@@ -223,9 +223,25 @@ export class SourceManagerView extends LitElement {
         ${this._ready ? html`
 
           ${this._sources.map((s) => html`
-            <action-row label="${s.name}" prefix="git" style="--row-height: 72px;">
+            <action-row 
+              label="${s.name}" 
+              prefix="git" 
+              variant=${s.error ? 'danger' : ''}
+              style="--row-height: ${s.error ? '120px' : '72px'};">
               ${s.location}
+              ${s.error ? html`
+                <div class="error-indicator">
+                  <sl-icon name="exclamation-triangle-fill" style="color: var(--sl-color-danger-600);"></sl-icon>
+                  <span class="error-text">${s.error}</span>
+                </div>
+              ` : nothing}
               <div slot="more" class="source-stats">
+                ${s.error ? html`
+                  <div class="stat error">
+                    <sl-icon name="exclamation-triangle-fill" style="color: var(--sl-color-danger-600);"></sl-icon>
+                    <span class="stat-label">Error</span>
+                  </div>
+                ` : nothing}
                 <div class="stat green">
                   <span class="stat-value">${s.pupCount}</span>
                   <span clas="stat-label">Pups</span>
@@ -318,6 +334,35 @@ export class SourceManagerView extends LitElement {
     }
     .stat.green {
       color: var(--sl-color-green-600);
+    }
+    .stat.error {
+      color: var(--sl-color-danger-600);
+    }
+
+    .error-indicator {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5em;
+      margin-top: 0.5em;
+      padding: 0.5em;
+      background-color: var(--sl-color-danger-50);
+      border: 1px solid var(--sl-color-danger-200);
+      border-radius: var(--sl-border-radius-small);
+      width: 100%;
+      box-sizing: border-box;
+      white-space: normal !important;
+      overflow: visible !important;
+      text-overflow: unset !important;
+    }
+
+    .error-text {
+      color: var(--sl-color-danger-700);
+      font-size: 0.875em;
+      font-family: 'Comic Neue', sans-serif;
+      flex: 1;
+      word-wrap: break-word;
+      white-space: normal;
+      line-height: 1.4;
     }
   ` 
 }

--- a/src/components/views/card-pup-install/index.js
+++ b/src/components/views/card-pup-install/index.js
@@ -118,6 +118,9 @@ class PupInstallCard extends LitElement {
                 <span class="source">
                   ${this.renderSourceIcon(source?.type)}
                   ${source?.location}
+                  ${source?.error ? html`
+                    <sl-icon name="exclamation-triangle-fill" style="color: var(--sl-color-danger-600); margin-left: 4px;"></sl-icon>
+                  ` : nothing}
                 </span>
                 <x-tag-set class="tag-set" .tags=${upstreamVersions} max=1></x-tag-set>
               </div>

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -481,7 +481,8 @@ class PkgController {
         location: sourceData.location || "",
         name: sourceData.name || "",
         pupCount: Object.keys(sourceData.pups || {}).length,
-        installedCount
+        installedCount,
+        error: sourceData.error || null
       };
     });
   }

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -26,7 +26,8 @@ class StoreView extends LitElement {
       busy: { type: Boolean },
       inspectedPup: { type: String },
       searchValue: { type: String },
-      _showSourceManagementDialog: { type: Boolean }
+      _showSourceManagementDialog: { type: Boolean },
+      _hasSourceErrors: { type: Boolean }
     }
   }
 
@@ -41,6 +42,7 @@ class StoreView extends LitElement {
     this.pkgController = pkgController;
     this.packageList = new PaginationController(this, undefined, this.itemsPerPage,{ initialSort });
     this._showSourceManagementDialog = false;
+    this._hasSourceErrors = false;
 
     this.inspectedPup;
     this.showCategories = false;
@@ -67,6 +69,7 @@ class StoreView extends LitElement {
     this.addEventListener('manage-sources-closed', this.handleManageSourcesClosed.bind(this));
     this.addEventListener('source-change', this.updatePups.bind(this));
     this.fetchBootstrap();
+    this.checkForSourceErrors();
   }
 
   disconnectedCallback() {
@@ -132,6 +135,7 @@ class StoreView extends LitElement {
       const storeListingRes = await getStoreListing()
       this.pkgController.setStoreData(storeListingRes);
       this.packageList.setData(this.pkgController.pups);
+      this.checkForSourceErrors();
     } catch (err) {
       console.error(err);
       this.fetchError = true;
@@ -144,6 +148,7 @@ class StoreView extends LitElement {
 
   updatePups() {
     this.pups = [...this.pkgController.pups];
+    this.checkForSourceErrors();
     this.requestUpdate('pups');
   }
 
@@ -178,6 +183,11 @@ class StoreView extends LitElement {
     this._showSourceManagementDialog = true;
   }
 
+  checkForSourceErrors() {
+    const sources = this.pkgController.getSourceList();
+    this._hasSourceErrors = sources.some(source => source.error);
+  }
+
   render() {
     const ready = (
       !this.fetchLoading &&
@@ -199,8 +209,8 @@ class StoreView extends LitElement {
       <page-banner title="Pup Store" subtitle="Dogebox">
         <div class="slogan-wrap">
           Extend your Dogebox with Pups
-          <sl-button size="large" variant="text" ?disabled=${this.fetchLoading} @click=${this.handleManageSourcesClick}>
-            <sl-icon name="database-fill-add" slot="prefix"></sl-icon>
+          <sl-button size="large" variant="text" ?disabled=${this.fetchLoading} @click=${this.handleManageSourcesClick} class=${this._hasSourceErrors ? 'source-error' : ''}>
+            <sl-icon name=${this._hasSourceErrors ? 'exclamation-triangle-fill' : 'database-fill-add'} slot="prefix"></sl-icon>
             Manage Sources
           </sl-button>
         </div>
@@ -298,6 +308,14 @@ class StoreView extends LitElement {
         justify-content: center;
         align-items: center;
       }
+    }
+
+    .source-error {
+      color: var(--sl-color-warning-600) !important;
+    }
+
+    .source-error::part(base) {
+      color: var(--sl-color-warning-600) !important;
     }
   `
 }

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -53,22 +53,22 @@ export function renderSectionBody(ready, SKELS, hasItems) {
 
     ${ready && hasItems('packages') ? html`
       <div class="pup-card-grid">
-        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.def.source?.id || 'unknown'}-${pkg.def.key}`, (pkg) => {
+        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.def?.source?.id || 'unknown'}-${pkg.def?.key || 'unknown'}`, (pkg) => {
           return html`
           <pup-install-card
             defaultIcon="box"
-            sourceId=${pkg.def.source.id}
-            defKey=${pkg.def.key}
-            pupName=${pkg.def.key}
-            version=${pkg.def.latestVersion}
-            logoBase64=${pkg.def.logoBase64}
-            .upstreamVersions=${pkg.def.versions[pkg.def.latestVersion]?.meta?.upstreamVersions || {}}
-            short="${pkg.def.versions[pkg.def.latestVersion]?.meta?.shortDescription}"
-            ?installed=${pkg.computed.isInstalled}
+            sourceId=${pkg.def?.source?.id || 'unknown'}
+            defKey=${pkg.def?.key || 'unknown'}
+            pupName=${pkg.def?.key || 'unknown'}
+            version=${pkg.def?.latestVersion || 'unknown'}
+            logoBase64=${pkg.def?.logoBase64 || ''}
+            .upstreamVersions=${pkg.def?.versions?.[pkg.def?.latestVersion]?.meta?.upstreamVersions || {}}
+            short="${pkg.def?.versions?.[pkg.def?.latestVersion]?.meta?.shortDescription || ''}"
+            ?installed=${pkg.computed?.isInstalled || false}
             ?updateAvailable=""
-            href=${pkg.computed.storeURL}
-            .source=${pkg.def.source}
-            .installationState=${{ id: pkg.computed.installationId, label: pkg.computed.installationLabel }}
+            href=${pkg.computed?.storeURL || '#'}
+            .source=${pkg.def?.source || null}
+            .installationState=${{ id: pkg.computed?.installationId || 'unknown', label: pkg.computed?.installationLabel || 'Unknown' }}
           ></pup-install-card>
         `})}
       </div>


### PR DESCRIPTION
 'Manage Sources' now indicates warning:
<img width="1230" alt="Screenshot 2025-06-24 at 2 30 05 pm" src="https://github.com/user-attachments/assets/956fa0d1-462b-4f45-8299-6cd0b97aee63" />

'Pup Sources' modal now shows sources with errors, includes warning message:
<img width="1229" alt="Screenshot 2025-06-24 at 2 30 21 pm" src="https://github.com/user-attachments/assets/01de75ed-1db2-428e-8f9f-36ba491ae3d4" />

dogeboxd PR: https://github.com/Dogebox-WG/dogeboxd/pull/119