### PR TITLE
Adds 'developer mode' to Install Options

### DIFF
--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -27,6 +27,8 @@ class PupInstallPage extends LitElement {
       busy: { type: Boolean },
       inflight: { type: Boolean },
       activityLogs: { type: Array },
+      autoInstallDependencies: { type: Boolean },
+      installWithDevModeEnabled: { type: Boolean },
     };
   }
 
@@ -43,6 +45,8 @@ class PupInstallPage extends LitElement {
     this.busy = false;
     this.inflight = false;
     this.activityLogs = [];
+    this.autoInstallDependencies = true;
+    this.installWithDevModeEnabled = false;
   }
 
   getPup() {
@@ -155,6 +159,7 @@ class PupInstallPage extends LitElement {
     const long = pkg.def.versions[pkg.def.latestVersion]?.meta?.longDescription || ''
     const noDescription = !short && !long
     const hasLogs = this.activityLogs.length
+    const isDevModeAvailable = pkg?.def?.devModeAvailable;
 
     return html`
       <div id="PageWrapper" class="${wrapperClasses}" ?data-freeze=${popover_page}>
@@ -166,11 +171,41 @@ class PupInstallPage extends LitElement {
 
         <section>
           <div class="section-title">
+            <h3>Install Options</h3>
+            <div>
+              <sl-checkbox
+                  ?checked=${this.autoInstallDependencies}
+                  @sl-change=${(e) => this.autoInstallDependencies = e.target.checked}
+                  size="small"
+                >
+                  Install required dependencies (if available)
+                </sl-checkbox>
+              </div>
+              ${isDevModeAvailable ? html`
+              <div>
+                <sl-checkbox
+                  ?checked=${this.installWithDevModeEnabled}
+                  @sl-change=${(e) => this.installWithDevModeEnabled = e.target.checked}
+                  size="small"
+                >
+                  Install with Development Mode enabled
+                </sl-checkbox>
+              </div>
+            ` : nothing}
+          </div>
+        </section>
+
+        <section>
+          <div class="section-title">
             <h3>About</h3>
             <reveal-row">
               ${long
                 ? html`<p style="margin-top: -12px;>${long}</p>`
-                : html`<small style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">Such empty, no description.</small>`
+                : html`
+                  <span style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">
+                    Such empty, no description.
+                  </span>
+                `
               }
             </reveal-row>
           </div>

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -155,11 +155,15 @@ class PupInstallPage extends LitElement {
       `
     }
 
-    const short = pkg.def.versions[pkg.def.latestVersion]?.meta?.shortDescription || '';
-    const long = pkg.def.versions[pkg.def.latestVersion]?.meta?.longDescription || ''
-    const noDescription = !short && !long
+    const long = pkg?.def?.versions[pkg?.def?.latestVersion]?.meta?.longDescription || ''
     const hasLogs = this.activityLogs.length
+    const hasDependencies = pkg?.def?.versions[pkg?.def?.latestVersion]?.dependencies?.length > 0;
     const isDevModeAvailable = pkg?.def?.devModeAvailable;
+
+    // Only show Install Options section if there is at least one option to show
+    const hasInstallOptions =
+      hasDependencies ||
+      isDevModeAvailable;
 
     return html`
       <div id="PageWrapper" class="${wrapperClasses}" ?data-freeze=${popover_page}>
@@ -169,38 +173,50 @@ class PupInstallPage extends LitElement {
           ${this.renderActions()}
         </section>
 
-        <section>
-          <div class="section-title">
-            <h3>Install Options</h3>
-            <div>
-              <sl-checkbox
+        ${hasInstallOptions ? html`
+          <section>
+            <div class="section-title">
+              <h3>Install Options</h3>
+              ${hasDependencies ? html`
+              <div>
+                <sl-checkbox
                   ?checked=${this.autoInstallDependencies}
                   @sl-change=${(e) => this.autoInstallDependencies = e.target.checked}
-                  size="small"
                 >
-                  Install required dependencies (if available)
+                <span style="display: flex; align-items: center; gap: 0.5em;">
+                  Install dependencies 
+                  <sl-tooltip content="Install all dependencies that are available. Uncheck to install only the pup itself.">
+                    <sl-icon name="info-circle"></sl-icon>
+                  </sl-tooltip>
+                  </span>
                 </sl-checkbox>
               </div>
+              ` : nothing}
               ${isDevModeAvailable ? html`
               <div>
                 <sl-checkbox
                   ?checked=${this.installWithDevModeEnabled}
                   @sl-change=${(e) => this.installWithDevModeEnabled = e.target.checked}
-                  size="small"
                 >
-                  Install with Development Mode enabled
+                  <span style="display: flex; align-items: center; gap: 0.5em;">
+                    Development Mode
+                    <sl-tooltip content="Install with Development Mode enabled.  Refer to the pup's documentation for more information.">
+                      <sl-icon name="info-circle"></sl-icon>
+                    </sl-tooltip>
+                  </span>
                 </sl-checkbox>
               </div>
             ` : nothing}
-          </div>
-        </section>
+            </div>
+          </section>
+        ` : nothing}
 
         <section>
           <div class="section-title">
             <h3>About</h3>
             <reveal-row">
               ${long
-                ? html`<p style="margin-top: -12px;>${long}</p>`
+                ? html`<span style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-700);">${long}</span>`
                 : html`
                   <span style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">
                     Such empty, no description.

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -6,29 +6,9 @@ export function openConfig() {
 }
 
 export function renderActions() {
-  // Initialize autoInstallDependencies if not already set
-  if (this.autoInstallDependencies === undefined) {
-    this.autoInstallDependencies = true;
-  }
-
-  // const pupDefinitionContext = this.context.store?.pupDefinitionContext
-
-  // const def = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
-  // const pkg = this.pkgController.getPup(def.installedId)
-
-  // const installationId = pkg?.computed?.installationId;
-  // const installationLabel = pkg?.computed?.installationLabel;
-  // const statusId = pkg?.computed?.statusId;
-  // const statusLabel = pkg?.computed?.statusLabel;
-
-  const pupContext = this.context.store?.pupContext;
   const pkg = this.getPup();
-
   const installationId = pkg.computed.installationId;
-  const installationLabel = pkg.computed.installationLabel;
-
   const isInstalled = pkg.computed.isInstalled;
-  const isLoadingStatus = ["installing"].includes(installationId);
 
   const styles = css`
     .action-wrap {
@@ -69,12 +49,6 @@ export function renderActions() {
               >
                 Such Install
               </sl-button>
-              <sl-checkbox
-                ?checked=${this.autoInstallDependencies}
-                @sl-change=${(e) => this.autoInstallDependencies = e.target.checked}
-              >
-                Install required dependencies if available
-              </sl-checkbox>
             </div>
           `
         : nothing}
@@ -119,7 +93,6 @@ export function renderActions() {
 }
 
 export async function handleInstall() {
-  const pupContext = this.context.store.pupContext;
   const pkg = this.getPup();
   this.inflight = true;
   const callbacks = {
@@ -140,7 +113,8 @@ export async function handleInstall() {
     sourceId: pkg.def.source.id,
     pupName: pkg.def.versions[pkg.def.latestVersion].meta.name,
     pupVersion: pkg.def.latestVersion,
-    autoInstallDependencies: this.autoInstallDependencies
+    autoInstallDependencies: Boolean(this.autoInstallDependencies),
+    installWithDevModeEnabled: Boolean(this.installWithDevModeEnabled)
   };
 
   await this.pkgController.requestPupAction("--", "install", callbacks, body);


### PR DESCRIPTION
This PR's purpose was to add a way for a developer to mark they want to install a pup with development mode enabled.

This would therefore be the second option that a user can set at install time.  So I took the time to tidy up the interface and put all install options under an 'Install Options' section.

The section is only visible if there is at least 1 option to show.  Ie, Dogecoin Core does not have dependencies nor a dev mode, so install options is not displayed.  Whereas, Identity has dependencies but no dev mode.  And s1w's test pup has Dev mode but not deps.

<img width="446" height="641" alt="Screenshot 2025-07-17 at 6 30 41 pm" src="https://github.com/user-attachments/assets/4fdf0460-b5fc-4597-95a3-28de975ee891" />

<img width="445" height="697" alt="Screenshot 2025-07-17 at 6 30 57 pm" src="https://github.com/user-attachments/assets/663a4e98-03be-4ada-a2f4-2964dd7fe032" />

<img width="445" height="703" alt="Screenshot 2025-07-17 at 6 31 16 pm" src="https://github.com/user-attachments/assets/7f37f216-2e6c-4bb4-9e03-93db0ad5bca9" />

