### PR TITLE
Enable SSH key management feature

### DIFF
--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -189,7 +189,7 @@ class SettingsPage extends LitElement {
             <action-row prefix="wifi" label="Wifi" @click=${notYet}>
               Add or remove Wifi networks
             </action-row>
-            <action-row prefix="key" label="Remote Access" href="/settings/remote-access" @click=${notYet}>
+            <action-row prefix="key" label="Remote Access" href="/settings/remote-access">
               Manage SSH settings and keys
             </action-row>
             <action-row prefix="usb-drive-fill" name="import-blockchain" label="Import Blockchain" .trigger=${this.handleMenuClick}>


### PR DESCRIPTION
Tested the frontend. Can add keys, delete keys.

Warns if attempting to add a private key
![ssh-key-add-1](https://github.com/user-attachments/assets/32930d5f-f3ea-4a74-8871-c05f7ed02e79)

Accepts a public key
![ssh-key-add-2](https://github.com/user-attachments/assets/0fcd56ab-156d-42ed-a68e-45f9a3b66338)
