### PR TITLE
Avoid log window overflow on T6

### DIFF
--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -659,10 +659,14 @@ export class LocationPickerView extends LitElement {
     .note-text {
       margin-block-start: 0em;
       margin-block-end: 0em;
+    }
 
     .activity-log-wrap {
       text-align: left;
       margin-top: 12px;
+      width: 100%;
+      max-width: 100%;
+      overflow: hidden;
     }
   `;
 }

--- a/src/components/views/x-activity-log.js
+++ b/src/components/views/x-activity-log.js
@@ -154,6 +154,8 @@ class ActivityLog extends LitElement {
         overflow-x: hidden;
         box-sizing: border-box;
         text-align: left;
+        width: 100%;
+        max-width: 100%;
       }
 
       div#LogFooter {
@@ -187,6 +189,7 @@ class ActivityLog extends LitElement {
         margin: 0px 0;
         padding: 0px;
         text-align: left;
+        max-width: 100%;
       }
     `;
   }


### PR DESCRIPTION
Fixes https://github.com/Dogebox-WG/dpanel/issues/130

Previously:
<img width="1326" height="1530" alt="image" src="https://github.com/user-attachments/assets/e655d6ef-0edf-4ffb-81c5-90262af3d723" />

Fixed:
<img width="536" height="708" alt="image" src="https://github.com/user-attachments/assets/6f0b5f49-fa6a-4e2a-8027-65698db9116b" />