### PR TITLE
Enable version in settings screen

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -142,6 +142,14 @@ class DPanelApp extends LitElement {
       if (res?.version?.release) {
         store.updateState({ appContext: { dbxVersion: res?.version?.release }})
       }
+      
+      // Set git commit info on appContext
+      if (res?.version?.git) {
+        store.updateState({ appContext: { 
+          gitCommit: res.version.git.commit,
+          gitDirty: res.version.git.dirty 
+        }})
+      }
 
       // Process pups
       if (res) {

--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -180,7 +180,7 @@ class SettingsPage extends LitElement {
             <h3>Menu</h3>
           </div>
           <div class="list-wrap">
-            <action-row prefix="info-circle" label="Version" href="/settings/versions" @click=${notYet}>
+            <action-row prefix="info-circle" label="Version" href="/settings/versions" .trigger=${this.handleMenuClick}>
               View version details
             </action-row>
             <action-row prefix="arrow-repeat" ?dot=${updateAvailable} label="Updates" href="/settings/updates" @click=${notYet}>
@@ -289,16 +289,17 @@ class SettingsPage extends LitElement {
 customElements.define("x-page-settings", SettingsPage);
 
 function renderVersionsDialog(store, closeFn) {
-  const { dbxVersion } = store.getContext('app')
+  const { dbxVersion, gitCommit, gitDirty } = store.getContext('app')
+  const displayVersion = dbxVersion || 'Unknown'
+  
   return html`
     <div style="text-align: center;">
       <h1>Versions</h1>
 
-      <div style="text-align: left; margin-bottom: 1em;">
-        <action-row prefix="box" expandable label="Dogebox ${dbxVersion}">
-          Bundles Dogeboxd, DKM & dPanel
-          <div slot="hidden"><small style="line-height: 1.1; display: block;">Lorem ad ex nostrud magna nisi ea enim magna exercitation aliquip enim amet ad deserunt sit irure aute proident.</div>
-        </action-row>
+      <div style="text-align: left; margin: 1em 0;">
+        <h2 style="margin: 0 0 0.5em 0;">Dogebox</h2>
+        <p style="margin: 0 0 0.5em 0;"><strong>Version:</strong> ${displayVersion}</p>
+        ${gitCommit ? html`<p style="margin: 0;"><strong>Git commit:</strong> ${gitCommit}${gitDirty ? ' (dirty)' : ''}</p>` : ''}
       </div>
 
       <sl-button variant="text" @click=${closeFn}>Dismiss</sl-button>


### PR DESCRIPTION
Enable 'version' button in settings screen.
This will show a modal with the Dogebox version and git commit. 

If the version file is missing, dogeboxd will provide a response indicating that the file is missing and include the current git branch name (for eg. custom build) - https://github.com/Dogebox-WG/dogeboxd/pull/153

<img width="911" height="876" alt="Screenshot_2025-10-15_at_3 56 51_pm" src="https://github.com/user-attachments/assets/7d5c7649-9720-42c7-a4e8-76ce0468ae27" />
