### PR TITLE
Jobs controller and system update button disable logic

### DIFF
--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -1,0 +1,73 @@
+import { store } from "/state/store.js";
+
+class JobsController {
+  constructor() {
+    this.observers = new Set();
+    this.state = this.deriveState(store.getContext("jobs"));
+
+    store.subscribe({
+      stateChanged: () => {
+        const jobsContext = store.getContext("jobs");
+        const nextState = this.deriveState(jobsContext);
+        const hasChanges = JSON.stringify(this.state) !== JSON.stringify(nextState);
+
+        if (hasChanges) {
+          this.state = nextState;
+          this.notifyObservers();
+        }
+      },
+    });
+  }
+
+  deriveState(jobsContext = {}) {
+    const jobs = Array.isArray(jobsContext?.jobs) ? jobsContext.jobs : [];
+    const activeSystemUpdate = jobs.find((job) => this.isJobPending(job, "system update"));
+    const status = ((activeSystemUpdate?.status || "").toLowerCase() || "active").replace(/_/g, " ");
+
+    return {
+      activeSystemUpdate,
+      isSystemUpdateLocked: Boolean(activeSystemUpdate),
+      systemUpdateStatus: status,
+    };
+  }
+
+  isJobPending(job, matchText) {
+    const name = (job?.displayName || "").toLowerCase();
+    const statusesToIgnore = ["completed", "failed", "cancelled"];
+    const status = (job?.status || "").toLowerCase();
+
+    return (
+      name.includes(matchText.toLowerCase()) && !statusesToIgnore.includes(status)
+    );
+  }
+
+  addObserver(observer) {
+    if (observer && typeof observer === "object") {
+      this.observers.add(observer);
+    }
+  }
+
+  removeObserver(observer) {
+    if (observer && this.observers.has(observer)) {
+      this.observers.delete(observer);
+    }
+  }
+
+  notifyObservers() {
+    for (const observer of this.observers) {
+      if (typeof observer?.onJobsUpdate === "function") {
+        observer.onJobsUpdate(this.state);
+      }
+    }
+  }
+
+  isSystemUpdateLocked() {
+    return this.state.isSystemUpdateLocked;
+  }
+
+  getActiveSystemUpdateStatus() {
+    return this.state.systemUpdateStatus;
+  }
+}
+
+export const jobsController = new JobsController();

--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -15,6 +15,7 @@ import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { getRouter } from "/router/index.js";
 import { pkgController } from "/controllers/package/index.js";
+import { jobsController } from "/controllers/jobs/index.js";
 import { promptPowerOff, promptReboot } from "./power-helpers.js";
 import { doBootstrap } from '/api/bootstrap/bootstrap.js';
 import { importBlockchain } from '/api/system/import-blockchain-data.js';
@@ -59,6 +60,8 @@ class SettingsPage extends LitElement {
       showImportLogs: { type: Boolean },
       systemLogs: { type: Array },
       showImportLogsModal: { type: Boolean },
+      isSystemUpdateLocked: { type: Boolean },
+      systemUpdateStatus: { type: String },
     };
   }
 
@@ -66,6 +69,9 @@ class SettingsPage extends LitElement {
     super();
     this.context = new StoreSubscriber(this, store);
     this.pkgController = pkgController;
+    this.isSystemUpdateLocked = jobsController.isSystemUpdateLocked();
+    this.systemUpdateStatus = jobsController.getActiveSystemUpdateStatus();
+    this.updatesRowDescription = this.buildUpdatesRowDescription();
     this.inflight_import_blockchain = false;
     this.showImportLogs = false;
     this.systemLogs = [];
@@ -76,6 +82,7 @@ class SettingsPage extends LitElement {
     super.connectedCallback();
     // Subscribe to pkgController for system activity updates
     this.pkgController.addObserver(this);
+    jobsController.addObserver(this);
     console.log('Settings page subscribed to pkgController for system activity updates');
   }
 
@@ -83,12 +90,27 @@ class SettingsPage extends LitElement {
     super.disconnectedCallback();
     // Unsubscribe from pkgController
     this.pkgController.removeObserver(this);
+    jobsController.removeObserver(this);
     
     // Reset import state when leaving the page
     this.inflight_import_blockchain = false;
     this.showImportLogs = false;
     this.systemLogs = [];
     this.showImportLogsModal = false;
+  }x
+
+  onJobsUpdate(state) {
+    if (
+      state?.isSystemUpdateLocked === this.isSystemUpdateLocked &&
+      state?.systemUpdateStatus === this.systemUpdateStatus
+    ) {
+      return;
+    }
+
+    this.isSystemUpdateLocked = state?.isSystemUpdateLocked;
+    this.systemUpdateStatus = state?.systemUpdateStatus;
+    this.updatesRowDescription = this.buildUpdatesRowDescription();
+    this.requestUpdate();
   }
 
   handleDialogClose() {
@@ -160,6 +182,14 @@ class SettingsPage extends LitElement {
     super.requestUpdate();
   }
 
+  buildUpdatesRowDescription() {
+    if (this.isSystemUpdateLocked) {
+      const status = this.systemUpdateStatus || "active";
+      return `Disabled while a system update is ${status}.`;
+    }
+    return "Check for updates";
+  }
+
   render() {
     const { updateAvailable } = store.getContext('sys')
     const dialog = store.getContext('dialog')
@@ -183,8 +213,8 @@ class SettingsPage extends LitElement {
             <action-row prefix="info-circle" label="Version" href="/settings/versions" @click=${notYet}>
               View version details
             </action-row>
-            <action-row prefix="arrow-repeat" ?dot=${updateAvailable} label="Updates" href="/settings/updates">
-              Check for updates
+            <action-row prefix="arrow-repeat" ?dot=${updateAvailable} label="Updates" href="/settings/updates" ?disabled=${this.isSystemUpdateLocked}>
+              ${this.updatesRowDescription}
             </action-row>
             <action-row prefix="wifi" label="Wifi" @click=${notYet}>
               Add or remove Wifi networks


### PR DESCRIPTION
Added jobs controller - allows observation of certain jobs eg. is a specific job in a specific state.
System update button is disabled if a system update is in progress or queued.