### PR TITLE
Sort pups alphabetically

### DIFF
--- a/src/pages/page-pup-library/index.js
+++ b/src/pages/page-pup-library/index.js
@@ -8,8 +8,12 @@ import { bindToClass } from '/utils/class-bind.js'
 import * as renderMethods from './renders/index.js';
 
 const initialSort = (a, b) => {
-  if (a.state.manifest.package < b.state.manifest.package) { return -1; }
-  if (a.state.manifest.package > b.state.manifest.package) { return 1; }
+  const nameA = a?.state?.manifest?.meta?.name || '';
+  const nameB = b?.state?.manifest?.meta?.name || '';
+  
+  // Default alphabetical sort
+  if (nameA < nameB) return -1;
+  if (nameA > nameB) return 1;
   return 0;
 }
 

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -11,8 +11,12 @@ import '/components/common/page-banner.js';
 import '/components/views/action-manage-sources/index.js';
 
 const initialSort = (a, b) => {
-  if (a?.def?.versions[a?.def?.versionLatest]?.meta?.name < b?.def?.versions[b?.def?.versionLatest]?.meta?.name) { return -1; }
-  if (a?.def?.versions[a?.def?.versionLatest] > b?.def?.versions[b?.def?.versionLatest]?.meta?.name) { return 1; }
+  const nameA = a?.def?.versions?.[a?.def?.latestVersion]?.meta?.name || '';
+  const nameB = b?.def?.versions?.[b?.def?.latestVersion]?.meta?.name || '';
+  
+  // Default alphabetical sort
+  if (nameA < nameB) return -1;
+  if (nameA > nameB) return 1;
   return 0;
 }
 


### PR DESCRIPTION
Previously the sorting on the pup-library page was based on a field that doesn't exist.
There was also a bug in the pup-store sorting too (missing `?.meta?.name`).
This meant that `Dogecoin Core Gateway` would appear before `Dogecoin Core` in the list:
<img width="1916" height="957" alt="Screenshot 2025-12-01 at 12 17 18 pm" src="https://github.com/user-attachments/assets/50a36b99-ece5-47b1-8836-449db6722c2c" />

Sorting methods have both been tidied up and sort on the correct name property:
<img width="1917" height="955" alt="Screenshot 2025-12-01 at 12 19 06 pm" src="https://github.com/user-attachments/assets/44c2c322-879b-464c-892b-9f1f23b17fe6" />
