### PR TITLE
Job card UI improvements

### DIFF
--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -40,8 +40,8 @@ class JobProgress extends LitElement {
       display: flex;
       align-items: center;
       gap: 0.5em;
-      flex: 0 0 200px;
-      min-width: 200px;
+      flex: 0 0 250px;
+      min-width: 250px;
     }
     
     .task-name {
@@ -92,7 +92,7 @@ class JobProgress extends LitElement {
     
     .progress-bar-container {
       flex: 1;
-      height: 24px;
+      height: 8px;
       background: #333;
       border-radius: 4px;
       overflow: hidden;
@@ -305,7 +305,7 @@ class JobProgress extends LitElement {
         <div class="job-row">
           <div class="task-label">
             <sl-icon name="${this.getStatusIcon(status)}" class="job-icon ${status}"></sl-icon>
-            <span class="task-name">
+            <span class="task-name" title="${displayName}">
               ${displayName}
             </span>
           </div>


### PR DESCRIPTION
Getting a start on this after discussing some small improvements with @patowens 

Increase width for job title from 200px to 250px.
Show full title on mouse hover for cases when the full title has been truncated.
Thinner progress bars so the page feels 'lighter'.

**Before:**
<img width="1657" height="1076" alt="Screenshot 2025-12-17 at 9 04 31 am" src="https://github.com/user-attachments/assets/15c998e1-dc2c-4eb3-93f9-c0b48c2c55c5" />

**After:**
<img width="1668" height="1074" alt="Screenshot 2025-12-17 at 9 02 44 am" src="https://github.com/user-attachments/assets/50c5c490-e5ca-4d99-af89-f79357abc3a8" />
