### PR TITLE
Pup configuration and dependency notifications/UI

### DIFF
--- a/src/components/common/action-row/action-row.js
+++ b/src/components/common/action-row/action-row.js
@@ -211,9 +211,6 @@ class ActionRow extends LitElement {
   `;
 
   handleClick = (e) => {
-    if (this.dot) {
-      this.dot = false;
-    }
     if (this.expandable) {
       this.expand = !this.expand;
       this.dispatchEvent(

--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -44,7 +44,8 @@
 
       const statusClassMap = classMap({
         status: true,
-        running: status === "running"
+        running: status === "running",
+        needs_attention: status === "Unmet Dependencies" || status === "Needs Config"
       });
       return html`
         <a class="anchor" href=${href} target="_self">
@@ -179,6 +180,11 @@
       span.status.running {
         color: #07ffae;
       }
+
+      span.status.needs_attention {
+        color: var(--sl-color-amber-600);
+      }
+
     `;
   }
 

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -333,7 +333,7 @@ class PupPage extends LitElement {
         <sl-switch slot="suffix" ?checked=${!disableActions && pkg.state.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight_startstop || labels.installationId !== "ready"}></sl-switch>
       </action-row>
 
-      <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>
+      <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick} ?disabled=${disableActions} ?dot=${labels.statusId === 'needs_config'}>
         Customise ${pkg.state.manifest.meta.name}
       </action-row>
 
@@ -357,7 +357,7 @@ class PupPage extends LitElement {
         </action-row>
       `}
 
-      <action-row prefix="boxes" name="deps" label="Dependencies" .trigger=${this.handleMenuClick}>
+      <action-row prefix="boxes" name="deps" label="Dependencies" .trigger=${this.handleMenuClick} ?dot=${labels.statusId === 'needs_deps'}>
         Functionality this pup depends on from other pups.
       </action-row>
 


### PR DESCRIPTION
Colour status yellow when pup needs configuration or has unmet dependencies (this text used to be grey just like when `Stopped`):
<img width="1114" height="587" alt="Screenshot 2025-12-17 at 1 18 52 pm" src="https://github.com/user-attachments/assets/4ce7d872-4146-43aa-b4dd-218d450d093b" />

Show action row dot for Customise when pup needs configuration:
<img width="1110" height="980" alt="Screenshot 2025-12-17 at 1 19 04 pm" src="https://github.com/user-attachments/assets/9caf51b9-7f00-4f62-8731-b1032ff3e99c" />

Also added this as it's related - Show action row dot for Dependencies when pup has unmet dependencies:
<img width="1103" height="988" alt="Screenshot 2025-12-17 at 1 18 58 pm" src="https://github.com/user-attachments/assets/aa703381-68e5-4565-ac90-46ca44b8aabd" />

Dots on action rows wont clear on click anymore, they now persist until the issue they're notifying is resolved