### PR TITLE
fix(install): Filter disks a bit better

### DIFF
--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -81,7 +81,7 @@ export class LocationPickerView extends LitElement {
   async fetchDisks() {
     this._allDisks = await getDisks();
     this._installDisks = this._allDisks.filter(
-      (d) => d?.suitability?.install?.usable,
+      (d) => d?.suitability?.install?.usable && d?.suitability?.install?.sizeOK,
     );
     this._bootMediaDisk = this._allDisks.find((d) => d.bootMedia);
     this._inflight_disks = false;


### PR DESCRIPTION
We're currently showing disks that are too small to handle the OS install