### PR TITLE
Move labels for selectable tooltips

### DIFF
--- a/src/components/views/x-metric/metric.js
+++ b/src/components/views/x-metric/metric.js
@@ -29,10 +29,6 @@ class MetricView extends LitElement {
     const tip = desc || String(this.metric.label || this.metric.name || '');
 
     return html`
-      <sl-tooltip .content=${tip} placement="top-start" hoist>
-        <span class="label">${this.metric.label}</span>
-      </sl-tooltip>
-
       <sl-copy-button
         class="copy"
         value="${this.metric.values}"
@@ -93,14 +89,6 @@ class MetricView extends LitElement {
       top: 2px;
       left: -2px;
     }
-
-    .label {
-      font-size: var(--metric-label-size, 0.9rem);
-      font-weight: 500;
-      max-height: 1.5rem;
-      line-height: 1.5rem;
-    }
-    .label:hover { cursor: help; }
 
     .value-container {
       width: 100%;

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -148,12 +148,11 @@ class PupPage extends LitElement {
     const callbacks = {
       onSuccess: () => dynamicForm.commitChanges(formNode),
       onError: (errorPayload) => {
-        dynamicForm.retainChanges(); // To cease the form from spinning
-        this.displayConfigUpdateErr(errorPayload); // Display a failure banner
+        dynamicForm.retainChanges();
+        this.displayConfigUpdateErr(errorPayload);
       },
     };
 
-    // Invoke pkgContrller model update, supplying data and callbacks
     const res = await pkgController.requestPupChanges(
       pupId,
       stagedChanges,
@@ -392,11 +391,22 @@ class PupPage extends LitElement {
 
       return html`
         <div class="metrics-wrap">
-          ${enriched.map((metric) => html`
-            <div class="metric-container">
-              <x-metric .metric=${metric}></x-metric>
-            </div>
-          `)}
+          ${enriched.map(
+            (metric) => html`
+              <div class="metric-container">
+                <div
+                  class="metric-label"
+                  title=${(metric.description ||
+                  metric.label ||
+                  metric.name ||
+                  "").trim()}
+                >
+                  ${metric.label ?? metric.name ?? ""}
+                </div>
+                <x-metric .metric=${metric}></x-metric>
+              </div>
+            `,
+          )}
         </div>
       `;
     };
@@ -412,11 +422,22 @@ class PupPage extends LitElement {
 
       return html`
         <div class="metrics-wrap">
-          ${pkg.stats.systemMetrics.map((metric) => html`
-            <div class="metric-container">
-              <x-metric .metric=${metric}></x-metric>
-            </div>
-          `)}
+          ${pkg.stats.systemMetrics.map(
+            (metric) => html`
+              <div class="metric-container">
+                <div
+                  class="metric-label"
+                  title=${(metric.description ||
+                  metric.label ||
+                  metric.name ||
+                  "").trim?.() || ""}
+                >
+                  ${metric.label ?? metric.name ?? ""}
+                </div>
+                <x-metric .metric=${metric}></x-metric>
+              </div>
+            `,
+          )}
         </div>
       `;
     };
@@ -635,11 +656,6 @@ class PupPage extends LitElement {
       color: var(--sl-color-neutral-400);
     }
 
-    section .section-title h3 {
-      text-transform: uppercase;
-      font-family: "Comic Neue";
-    }
-
     .update-badge {
       font-family: 'Comic Neue';
       font-weight: bold;
@@ -698,6 +714,14 @@ class PupPage extends LitElement {
       width: 100%;
     }
 
+    .metric-label {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: #07ffae;
+      margin: 0 0 0.35rem 0;
+      user-select: text;
+      pointer-events: auto;
+    }
   `;
 }
 


### PR DESCRIPTION
Move metric labels outside chart for selectable tooltips and simplify sparkline rendering to point data.

<img width="2736" height="1153" alt="image" src="https://github.com/user-attachments/assets/4f842b33-69b5-46f1-85c7-bc5e395f7a8a" />
