### PR TITLE
Logout button and Settings page tidy

### DIFF
--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -239,8 +239,6 @@ class SettingsPage extends LitElement {
           </div>
         </section>
 
-
-
         <section>
           <div class="section-title">
             <h3>Power</h3>
@@ -256,7 +254,7 @@ class SettingsPage extends LitElement {
 
         <section>
           <div class="section-title">
-            <h3>Logout</h3>
+            <h3>Security</h3>
           </div>
           <action-row prefix="box-arrow-right" label="Logout" href="/logout">
             Sign out and return to login


### PR DESCRIPTION
In testing https://github.com/Dogebox-WG/dogeboxd/pull/181 it became apparent there's no logout button in dpanel, however a `/logout` endpoint does exist.

This PR adds a logout button into the Settings page which calls `/logout`, this logs the user outs and takes them to the login page.

There's quite a few settings now, so also proposing some new categorisations to help split things out:

## General
- Version
- Update
## Configure
- Wifi
- Remote Access
- Import Blockchain
- Language
- Date and Time
- Customise OS
## Power
- Shutdown
- Restart
## Logout
- Logout
## Help
- Documentation

<img width="1534" height="1370" alt="Screenshot 2026-02-12 at 8 54 45 am" src="https://github.com/user-attachments/assets/a771c01d-86da-4418-a18a-134740014500" />
