### PR TITLE
fix: missing icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Dogebox Panel",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && rm -rf dist/vendor && cp -R src/vendor dist/vendor",
     "preview": "vite preview",
     "clean": "rm -rf dist"
   },


### PR DESCRIPTION
Icons rely on Shoelace element `sl-icon`. Shoelace is vendored in atm so we need to copy `src/vendor` to `dist/vendor` on build