### PR TITLE
Network names - frontend

### DIFF
--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -170,14 +170,14 @@ class SelectNetwork extends LitElement {
       if (network.type === "ethernet") {
         const mappedLabel =
           typeof network.label === "string" ? network.label.trim() : "";
-        const ethernetName = mappedLabel
+        let ethernetName = mappedLabel
           ? `${mappedLabel} - ${network.interface}`
           : `Ethernet - ${network.interface}`;
-        const connectedSuffix = network.active ? " (connected)" : "";
+        if (network.active) ethernetName += " (connected)";
 
         return this._networks.push({
           ...network,
-          label: `${ethernetName}${connectedSuffix}`,
+          label: ethernetName,
           value: network.interface,
         });
       }


### PR DESCRIPTION
On the T6, network interfaces were showing in the list as `Ethernet - enP4p65s0` and `Ethernet - enP2p33s0` which was not possible to relate to the labeled `ETH1` and `ETH2` ports on the device. 

These changes map the labels if a mapping is available, as well as displaying if the interface is connected.
So it will now show as (for eg):
`ETH1 - enP4p65s0 (connected)`
`ETH2 - enP2p33s0`

<img width="681" height="679" alt="Screenshot 2026-02-20 at 3 01 55 pm" src="https://github.com/user-attachments/assets/29fe7668-5374-4533-99b6-3c29a2719bd6" />

Backend: https://github.com/Dogebox-WG/dogeboxd/pull/184