### PR TITLE
Secure context for websockets (when appropriate)

### DIFF
--- a/src/state/store.js
+++ b/src/state/store.js
@@ -19,7 +19,7 @@ class Store {
     };
     this.networkContext = this.networkContext || {
       apiBaseUrl: `${window.location.protocol}//${window.location.hostname}:3000`,
-      wsApiBaseUrl: `ws://${window.location.hostname}:3000`,
+      wsApiBaseUrl: `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.hostname}:3000`,
       overrideBaseUrl: false,
       overrideSocketBaseUrl: false,
       useMocks: false,


### PR DESCRIPTION
Commonly, dpanel is accessed over a local network via localhost and in an insecure web context.

However, we are not far off from having it effectively run in a secure context.
Thus far, the only preventative thing I can see is that our web socket connection is set as `ws://` (which is the insecure context protocol), `wss://` is the secure context protocol.

This PR sets the protocol to `wss://` if dpanel is accessed via `https://`, and falls back to `ws://` when not.