### PR TITLE
Log viewer improvements - frontend

### DIFF
--- a/src/api/sockets.js
+++ b/src/api/sockets.js
@@ -42,8 +42,12 @@ export default class WebSocketClient extends ReactiveClass {
   }
 
   startWebSocketConnection() {
-    const urlWithAuth = this.url + `?token=${this.token}`
-    this.socket = new WebSocket(urlWithAuth);
+    // Preserve any existing query params, then append the auth token.
+    const socketUrl = new URL(this.url);
+    if (this.token) {
+      socketUrl.searchParams.set('token', this.token);
+    }
+    this.socket = new WebSocket(socketUrl.toString());
     this.socket.onopen = () => {
       this._isConnected = true;
       this.onOpen();

--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -3,18 +3,22 @@ import { store } from '/state/store.js';
 import WebSocketClient from '/api/sockets.js';
 import { mockedLogRunner } from './log.mocks.js';
 
+const MAX_LOG_LINES = 1000;
+
 class LogViewer extends LitElement {
   static get properties() {
     return {
       autostart: { type: Boolean },
       logs: { type: Array },
       isConnected: { type: Boolean },
+      isLoadingHistory: { type: Boolean },
       follow: { type: Boolean },
       pupId: { type: String },
       jobId: { type: String },
       closing: { type: Boolean, reflect: true },
       animateOpen: { type: Boolean },
       opening: { type: Boolean, reflect: true },
+      isDownloading: { type: Boolean },
     };
   }
 
@@ -24,17 +28,20 @@ class LogViewer extends LitElement {
     this.pupId = "";
     this.jobId = "";
     this.isConnected = false;
+    this.isLoadingHistory = false;
     this.wsClient = null;
     this.autostart = true;
     this.follow = true; // Default to true, user can disable temporarily
     this.closing = false;
     this.animateOpen = false;
     this.opening = false;
+    this.isDownloading = false;
+    this._streamToken = 0;
   }
 
   connectedCallback() {
     super.connectedCallback();
-    this.setupSocketConnection();
+    this.startLogStream();
     this._boundTransitionEnd = this._onTransitionEnd.bind(this);
     this.addEventListener('transitionend', this._boundTransitionEnd);
     if (this.animateOpen && (this.jobId || this.pupId)) {
@@ -49,6 +56,7 @@ class LogViewer extends LitElement {
   }
 
   disconnectedCallback() {
+    this._streamToken += 1;
     if (this._openRaf) {
       cancelAnimationFrame(this._openRaf);
       this._openRaf = null;
@@ -76,22 +84,9 @@ class LogViewer extends LitElement {
       // Only reconnect if the ID actually changed (not just initial render)
       if (oldJobId !== undefined || oldPupId !== undefined) {
         if (oldJobId !== newJobId || oldPupId !== newPupId) {
-          // Disconnect old connection
-          if (this.wsClient) {
-            this.wsClient.disconnect();
-            this.wsClient = null;
-            this.isConnected = false;
-          }
-          
-          // Clear old logs
-          this.logs = [];
-          
-          // Setup new connection
-          this.setupSocketConnection();
-          
-          if (this.autostart && this.wsClient) {
-            this.wsClient.connect();
-          }
+          // Disconnect old connection, clear old logs, and setup the new connection.
+          this.resetLogStream();
+          this.startLogStream();
         }
       }
     }
@@ -130,6 +125,10 @@ class LogViewer extends LitElement {
   }
 
   handleToggleConnection() {
+    if (!this.wsClient) {
+      return;
+    }
+
     if (this.wsClient.isConnected) {
       this.wsClient.disconnect();
     } else {
@@ -137,24 +136,133 @@ class LogViewer extends LitElement {
     }
   }
 
-  setupSocketConnection() {
+  getLogTarget() {
+    // Must have either pupId or jobId
+    if (!this.pupId && !this.jobId) {
+      return null;
+    }
+
+    // Determine which endpoint to use
+    return {
+      logType: this.jobId ? 'job' : 'pup',
+      logId: this.jobId || this.pupId,
+    };
+  }
+
+  resetLogStream() {
+    this._streamToken += 1;
+    this.isLoadingHistory = false;
+    if (this.wsClient) {
+      this.wsClient.disconnect();
+      this.wsClient = null;
+    }
+    this.isConnected = false;
+    this.logs = [];
+  }
+
+  async startLogStream() {
+    const target = this.getLogTarget();
+    if (!target) {
+      return;
+    }
+
+    const streamToken = ++this._streamToken;
+
+    if (store.networkContext.useMocks) {
+      this.isLoadingHistory = false;
+      this.setupSocketConnection(target);
+      return;
+    }
+
+    this.isLoadingHistory = true;
+    this.logs = [];
+    this.requestUpdate();
+
+    try {
+      const { lines, resumeToken } = await this.fetchInitialLogs(target);
+      if (streamToken !== this._streamToken) {
+        return;
+      }
+
+      this.logs = this.trimLogs(lines);
+      this.setupSocketConnection(target, resumeToken);
+      await this.requestUpdate();
+      this.scrollToBottomIfNeeded();
+    } catch (error) {
+      if (streamToken !== this._streamToken) {
+        return;
+      }
+
+      console.warn('[Log Viewer] Failed to load initial logs, falling back to live stream only.', error);
+      this.setupSocketConnection(target);
+    } finally {
+      if (streamToken === this._streamToken) {
+        this.isLoadingHistory = false;
+        this.requestUpdate();
+      }
+    }
+  }
+
+  async fetchInitialLogs(target) {
+    const headers = {};
+    if (store.networkContext.token) {
+      headers.Authorization = `Bearer ${store.networkContext.token}`;
+    }
+
+    const response = await fetch(
+      `${store.networkContext.apiBaseUrl}/log/${target.logType}/${target.logId}/tail?limit=${MAX_LOG_LINES}`,
+      { headers }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Initial log load failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    return {
+      lines: Array.isArray(payload.lines) ? payload.lines : [],
+      resumeToken: typeof payload.resumeToken === 'string' ? payload.resumeToken : null,
+    };
+  }
+
+  trimLogs(logs) {
+    return logs.length > MAX_LOG_LINES
+      ? logs.slice(logs.length - MAX_LOG_LINES)
+      : logs;
+  }
+
+  scrollToBottomIfNeeded() {
+    if (!this.follow) {
+      return;
+    }
+
+    const logContainer = this.shadowRoot?.querySelector('#LogContainer');
+    if (!logContainer) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      logContainer.scrollTop = logContainer.scrollHeight;
+    });
+  }
+
+  setupSocketConnection(target = this.getLogTarget(), resumeToken = null) {
     // Prevent duplicate connections
     if (this.isConnected || this.wsClient) {
       return;
     }
 
-    // Must have either pupId or jobId
-    if (!this.pupId && !this.jobId) {
+    if (!target) {
       return;
     }
 
-    // Determine which endpoint to use
-    const logType = this.jobId ? 'job' : 'pup';
-    const logId = this.jobId || this.pupId;
-    const wsUrl = `${store.networkContext.wsApiBaseUrl}/ws/log/${logType}/${logId}`;
+    const wsUrl = new URL(`/ws/log/${target.logType}/${target.logId}`, store.networkContext.wsApiBaseUrl);
+    if (resumeToken !== null && resumeToken !== undefined) {
+      wsUrl.searchParams.set('resumeToken', String(resumeToken));
+    }
 
     this.wsClient = new WebSocketClient(
-      wsUrl,
+      wsUrl.toString(),
       store.networkContext,
       mockedLogRunner
     );
@@ -186,16 +294,14 @@ class LogViewer extends LitElement {
         return;
       }
       
-      this.logs = [...this.logs, logMessage];
+      const updatedLogs = [...this.logs, logMessage];
+      this.logs = this.trimLogs(updatedLogs);
       await this.requestUpdate();
-      if (this.follow) {
-        const logContainer = this.shadowRoot.querySelector('#LogContainer');
-        logContainer.scrollTop = logContainer.scrollHeight;
-      }
+      this.scrollToBottomIfNeeded();
     };
 
     this.wsClient.onError = (event) => {
-      console.error(`[Log Viewer] WebSocket error for ${logType} ${logId}:`, event);
+      console.error(`[Log Viewer] WebSocket error for ${target.logType} ${target.logId}:`, event);
       this.isConnected = false;
       this.requestUpdate();
     };
@@ -210,31 +316,78 @@ class LogViewer extends LitElement {
     }
   }
 
-  handleDownloadClick(e) {
+  async handleDownloadClick(e) {
     e.stopPropagation(); // Prevent event from bubbling up to parent
-    const contentDiv = this.shadowRoot.querySelector("#LogContainer");
-    
-    let textToDownload = '';
+    if (this.isDownloading) {
+      return;
+    }
 
-    // Extracting text from each <li> and adding a newline after each
-    contentDiv.querySelectorAll('li').forEach(li => {
-      textToDownload += li.textContent + '\n';
-    });
+    if (store.networkContext.useMocks || !this.getLogTarget()) {
+      this.downloadBufferedLogs();
+      return;
+    }
 
-    // Creating a Blob for the text
+    this.isDownloading = true;
+
+    try {
+      await this.downloadFullLog();
+    } catch (error) {
+      console.warn('[Log Viewer] Failed to download full log, falling back to buffered logs.', error);
+      this.downloadBufferedLogs();
+    } finally {
+      this.isDownloading = false;
+    }
+  }
+
+  async downloadFullLog() {
+    const target = this.getLogTarget();
+    if (!target) {
+      throw new Error('No log target available for download');
+    }
+
+    const headers = {};
+
+    if (store.networkContext.token) {
+      headers.Authorization = `Bearer ${store.networkContext.token}`;
+    }
+
+    const response = await fetch(
+      `${store.networkContext.apiBaseUrl}/log/${target.logType}/${target.logId}/download`,
+      { headers }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Download failed with status ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    const filename = this.getDownloadFilename(response, target.logId);
+    this.triggerDownload(blob, filename);
+  }
+
+  downloadBufferedLogs() {
+    const logId = this.jobId || this.pupId || 'unknown';
+    const textToDownload = this.logs.length > 0 ? `${this.logs.join('\n')}\n` : '';
     const blob = new Blob([textToDownload], { type: 'text/plain' });
+    this.triggerDownload(blob, `log_${logId}_${Date.now()}.txt`);
+  }
 
-    // Creating an anchor element to trigger download
+  getDownloadFilename(response, logId) {
+    const contentDisposition = response.headers.get('Content-Disposition');
+    const filenameMatch = contentDisposition?.match(/filename="?([^"]+)"?/);
+    return filenameMatch?.[1] || `log_${logId}_${Date.now()}.txt`;
+  }
+
+  triggerDownload(blob, filename) {
+    const blobUrl = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.setAttribute('no-intercept', true)
-    a.href = URL.createObjectURL(blob);
-    a.download = `log_${this.pupId}_${Date.now()}.txt`;
+    a.setAttribute('no-intercept', true);
+    a.href = blobUrl;
+    a.download = filename;
     document.body.appendChild(a);
     a.click();
-
-    // Cleanup the temporary element
     document.body.removeChild(a);
-
+    URL.revokeObjectURL(blobUrl);
   }
 
   _onTransitionEnd(e) {
@@ -263,7 +416,11 @@ class LogViewer extends LitElement {
             </ul>
           ` : html`
             <div class="no-logs-message">
-              ${this.isConnected ? 'Waiting for logs...' : 'Logs not available'}
+              ${this.isLoadingHistory
+                ? 'Loading logs...'
+                : this.isConnected
+                  ? 'Waiting for logs...'
+                  : 'Logs not available'}
             </div>
           `}
         </div>
@@ -280,6 +437,8 @@ class LogViewer extends LitElement {
             variant="text"
             size="large"
             target="_blank"
+            ?loading=${this.isDownloading}
+            ?disabled=${this.isDownloading}
             @click=${this.handleDownloadClick}
             >Download
             <sl-icon name="download" slot="suffix"></sl-icon>


### PR DESCRIPTION
This fixes an issue where pups with noisy logs would have poor performance both in the initial load of the logs page (5+ seconds) and continuous display of logs (browser may crash as logs in memory increases indefinitely)

- Fetch the latest log tail before opening the websocket (latest 1000 logs are loaded quickly)
- Use the backend resume token to continue live log streaming
- Displayed logs is capped at 1000 to keep memory usage low
- Use the full-log download endpoint for the download action
- Keep buffered log download available as a fallback when full download is unavailable or fails

Related backend PR: https://github.com/Dogebox-WG/dogeboxd/pull/200