### PR TITLE
Setup logs - frontend

### DIFF
--- a/src/api/system/get-bootstrap.mocks.js
+++ b/src/api/system/get-bootstrap.mocks.js
@@ -5,6 +5,7 @@ export const getResponse = {
   res: {
     success: true,
     setupFacts: {
+      setupSessionId: "mock-setup-session",
       hasGeneratedKey: false,
       hasConfiguredNetwork: false,
       hasCompletedInitialConfiguration: false

--- a/src/api/system/post-bootstrap.mocks.js
+++ b/src/api/system/post-bootstrap.mocks.js
@@ -3,6 +3,6 @@ export const postResponse = {
   method: "post",
   group: "system",
   res: {
-    success: true
+    jobId: "mock-bootstrap-job"
   }
 };

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -136,10 +136,16 @@ class AppModeApp extends LitElement {
         !parsedValue ||
         !Number.isInteger(parsedValue.stepNumber) ||
         typeof parsedValue.setupSessionId !== "string" ||
-        !parsedValue.setupSessionId
+        !parsedValue.setupSessionId ||
+        (parsedValue.bootstrapStartError !== undefined &&
+          typeof parsedValue.bootstrapStartError !== "string")
       ) {
         this._clearPersistedSetupStep();
         return null;
+      }
+
+      if (typeof parsedValue.bootstrapStartError !== "string") {
+        parsedValue.bootstrapStartError = "";
       }
 
       return parsedValue;
@@ -149,7 +155,7 @@ class AppModeApp extends LitElement {
     }
   }
 
-  _writePersistedSetupStep(stepNumber, setupSessionId) {
+  _writePersistedSetupStep(stepNumber, setupSessionId, bootstrapStartError = "") {
     try {
       if (!setupSessionId) {
         this._logSetupFlow("persistedStep:write-skipped", {
@@ -162,12 +168,17 @@ class AppModeApp extends LitElement {
 
       window.sessionStorage.setItem(
         SETUP_STEP_STORAGE_KEY,
-        JSON.stringify({ stepNumber, setupSessionId }),
+        JSON.stringify({
+          stepNumber,
+          setupSessionId,
+          bootstrapStartError,
+        }),
       );
       this._logSetupFlow("persistedStep:write", {
         step: stepNumber,
         stepName: this._getStepName(stepNumber),
         setupSessionId,
+        hasBootstrapStartError: !!bootstrapStartError,
       });
     } catch (error) {
       this._logSetupFlow("persistedStep:write-failed", { error });
@@ -414,6 +425,22 @@ class AppModeApp extends LitElement {
         return resolvedStep;
       }
 
+      const persistedStep = this._readPersistedSetupStep();
+      const hasPersistedBootstrapStartError =
+        persistedStep?.setupSessionId === setupState.setupSessionId &&
+        persistedStep.stepNumber === STEP_BOOTSTRAP &&
+        !!persistedStep.bootstrapStartError;
+
+      if (hasPersistedBootstrapStartError) {
+        this.bootstrapStartError = persistedStep.bootstrapStartError;
+        this._logSetupFlow("determineStartingStep:result", {
+          reason: "persisted-bootstrap-start-error",
+          step: STEP_BOOTSTRAP,
+          stepName: this._getStepName(STEP_BOOTSTRAP),
+        });
+        return STEP_BOOTSTRAP;
+      }
+
       if (!this.isLoggedIn) {
         if (hasGeneratedKey || hasConfiguredNetwork || activeBootstrapJobId) {
           this._logSetupFlow("determineStartingStep:result", {
@@ -548,6 +575,7 @@ class AppModeApp extends LitElement {
         this._writePersistedSetupStep(
           this.activeStepNumber,
           this.setupState?.setupSessionId,
+          this.activeStepNumber === STEP_BOOTSTRAP ? this.bootstrapStartError : "",
         );
       } else if (this.activeStepNumber === STEP_LOGIN && this.setupState) {
         this._clearPersistedSetupStep();
@@ -567,6 +595,17 @@ class AppModeApp extends LitElement {
         next: this.isLoggedIn,
         hasToken: !!this.context.store.networkContext.token,
       });
+    }
+
+    if (
+      changedProperties.has("bootstrapStartError") &&
+      this.activeStepNumber === STEP_BOOTSTRAP
+    ) {
+      this._writePersistedSetupStep(
+        this.activeStepNumber,
+        this.setupState?.setupSessionId,
+        this.bootstrapStartError,
+      );
     }
   }
 

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -64,6 +64,18 @@ const STEP_NETWORK = 5;
 const STEP_BOOTSTRAP = 6;
 const STEP_DONE = 7;
 const STEP_INSTALL = 8;
+const SETUP_STEP_STORAGE_KEY = "recovery-setup-current-step";
+const STEP_NAMES = {
+  [STEP_LOGIN]: "login",
+  [STEP_INTRO]: "intro",
+  [STEP_SYS_SETTINGS]: "system-settings",
+  [STEP_SET_PASSWORD]: "set-password",
+  [STEP_GENERATE_KEY]: "generate-key",
+  [STEP_NETWORK]: "network",
+  [STEP_BOOTSTRAP]: "bootstrap",
+  [STEP_DONE]: "done",
+  [STEP_INSTALL]: "install",
+};
 
 class AppModeApp extends LitElement {
   static styles = [appModeStyles, navStyles];
@@ -102,10 +114,186 @@ class AppModeApp extends LitElement {
     };
   }
 
+  _logSetupFlow(message, details = {}) {
+    console.log("[recovery-setup]", message, details);
+  }
+
+  _getStepName(stepNumber) {
+    return STEP_NAMES[stepNumber] ?? `unknown-${stepNumber}`;
+  }
+
+  _readPersistedSetupStep() {
+    try {
+      const rawValue = window.sessionStorage.getItem(SETUP_STEP_STORAGE_KEY);
+      if (rawValue === null) {
+        return null;
+      }
+
+      const parsedValue = JSON.parse(rawValue);
+      if (
+        !parsedValue ||
+        !Number.isInteger(parsedValue.stepNumber) ||
+        typeof parsedValue.setupSessionId !== "string" ||
+        !parsedValue.setupSessionId
+      ) {
+        this._clearPersistedSetupStep();
+        return null;
+      }
+
+      return parsedValue;
+    } catch (error) {
+      this._logSetupFlow("persistedStep:read-failed", { error });
+      return null;
+    }
+  }
+
+  _writePersistedSetupStep(stepNumber, setupSessionId) {
+    try {
+      if (!setupSessionId) {
+        this._logSetupFlow("persistedStep:write-skipped", {
+          reason: "missing-setup-session-id",
+          step: stepNumber,
+          stepName: this._getStepName(stepNumber),
+        });
+        return;
+      }
+
+      window.sessionStorage.setItem(
+        SETUP_STEP_STORAGE_KEY,
+        JSON.stringify({ stepNumber, setupSessionId }),
+      );
+      this._logSetupFlow("persistedStep:write", {
+        step: stepNumber,
+        stepName: this._getStepName(stepNumber),
+        setupSessionId,
+      });
+    } catch (error) {
+      this._logSetupFlow("persistedStep:write-failed", { error });
+    }
+  }
+
+  _clearPersistedSetupStep() {
+    try {
+      window.sessionStorage.removeItem(SETUP_STEP_STORAGE_KEY);
+      this._logSetupFlow("persistedStep:cleared");
+    } catch (error) {
+      this._logSetupFlow("persistedStep:clear-failed", { error });
+    }
+  }
+
+  _getAllowedPersistedSteps(setupState) {
+    const {
+      hasCompletedInitialConfiguration,
+      hasGeneratedKey,
+      hasConfiguredNetwork,
+      activeBootstrapJobId,
+      isForbidden,
+    } = setupState;
+
+    if (isForbidden || hasCompletedInitialConfiguration) {
+      return new Set();
+    }
+
+    const pristineSetup =
+      !hasGeneratedKey && !hasConfiguredNetwork && !activeBootstrapJobId;
+
+    if (pristineSetup) {
+      return new Set([
+        STEP_INTRO,
+        STEP_SYS_SETTINGS,
+        STEP_SET_PASSWORD,
+        STEP_GENERATE_KEY,
+      ]);
+    }
+
+    if (activeBootstrapJobId) {
+      if (!this.isLoggedIn) {
+        return new Set();
+      }
+
+      return new Set([
+        STEP_INTRO,
+        STEP_SYS_SETTINGS,
+        STEP_SET_PASSWORD,
+        STEP_GENERATE_KEY,
+        STEP_NETWORK,
+        STEP_BOOTSTRAP,
+      ]);
+    }
+
+    if (hasGeneratedKey) {
+      if (!this.isLoggedIn) {
+        return new Set();
+      }
+
+      return new Set([
+        STEP_INTRO,
+        STEP_SYS_SETTINGS,
+        STEP_SET_PASSWORD,
+        STEP_GENERATE_KEY,
+        STEP_NETWORK,
+      ]);
+    }
+
+    return new Set([
+      STEP_INTRO,
+      STEP_SYS_SETTINGS,
+      STEP_SET_PASSWORD,
+      STEP_GENERATE_KEY,
+    ]);
+  }
+
+  _resolvePersistedSetupStep(setupState, fallbackStep) {
+    const persistedStep = this._readPersistedSetupStep();
+    if (persistedStep === null) {
+      return fallbackStep;
+    }
+
+    if (persistedStep.setupSessionId !== setupState.setupSessionId) {
+      this._logSetupFlow("persistedStep:ignored", {
+        reason: "setup-session-id-mismatch",
+        persistedStep: persistedStep.stepNumber,
+        persistedStepName: this._getStepName(persistedStep.stepNumber),
+        persistedSetupSessionId: persistedStep.setupSessionId,
+        currentSetupSessionId: setupState.setupSessionId,
+        fallbackStep,
+        fallbackStepName: this._getStepName(fallbackStep),
+      });
+      return fallbackStep;
+    }
+
+    const allowedSteps = this._getAllowedPersistedSteps(setupState);
+    if (!allowedSteps.has(persistedStep.stepNumber)) {
+      this._logSetupFlow("persistedStep:ignored", {
+        reason: "step-not-allowed",
+        persistedStep: persistedStep.stepNumber,
+        persistedStepName: this._getStepName(persistedStep.stepNumber),
+        fallbackStep,
+        fallbackStepName: this._getStepName(fallbackStep),
+      });
+      return fallbackStep;
+    }
+
+    this._logSetupFlow("persistedStep:using", {
+      persistedStep: persistedStep.stepNumber,
+      persistedStepName: this._getStepName(persistedStep.stepNumber),
+      setupSessionId: persistedStep.setupSessionId,
+      fallbackStep,
+      fallbackStepName: this._getStepName(fallbackStep),
+    });
+    return persistedStep.stepNumber;
+  }
+
   set setupState(newValue) {
     this._setupState = newValue;
     if (newValue) {
       const stepNumber = this._determineStartingStep(newValue);
+      this._logSetupFlow("setupState updated", {
+        setupState: newValue,
+        chosenStep: stepNumber,
+        chosenStepName: this._getStepName(stepNumber),
+        isLoggedIn: this.isLoggedIn,
+      });
       this.activeStepNumber = stepNumber;
     }
   }
@@ -117,6 +305,11 @@ class AppModeApp extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.isLoggedIn = !!store.networkContext.token;
+    this._logSetupFlow("connected", {
+      isLoggedIn: this.isLoggedIn,
+      hasToken: !!store.networkContext.token,
+      location: window.location.href,
+    });
 
     // Instantiate a web socket connection and add main app as an observer
     this.mainChannel.addObserver(this);
@@ -127,9 +320,15 @@ class AppModeApp extends LitElement {
 
   async fetchSetupState() {
     this.loading = true;
+    this._logSetupFlow("fetchSetupState:start", {
+      isLoggedIn: this.isLoggedIn,
+      hasToken: !!store.networkContext.token,
+    });
     const response = await getSetupBootstrap({ noLogoutRedirect: true });
+    this._logSetupFlow("fetchSetupState:response", response);
 
     if (!response.success && response.status === 401) {
+      this._logSetupFlow("fetchSetupState:forbidden", response);
       this.setupState = { isForbidden: true };
       this.loading = false;
       return;
@@ -149,7 +348,9 @@ class AppModeApp extends LitElement {
   }
 
   async fetchRecoveryState() {
+    this._logSetupFlow("fetchRecoveryState:start");
     const response = await getRecoveryBootstrap({ noLogoutRedirect: true });
+    this._logSetupFlow("fetchRecoveryState:response", response);
 
     if (!response.recoveryFacts) {
       // Only show alert if we're logged in
@@ -174,41 +375,115 @@ class AppModeApp extends LitElement {
       activeBootstrapJobId,
       isForbidden,
     } = setupState;
+    const isPristineSetup =
+      !hasGeneratedKey && !hasConfiguredNetwork && !activeBootstrapJobId;
+
+    this._logSetupFlow("determineStartingStep:input", {
+      setupState,
+      isLoggedIn: this.isLoggedIn,
+      bootstrapJobId: this.bootstrapJobId,
+    });
 
     // First check if we're forbidden
     if (isForbidden) {
+      this._logSetupFlow("determineStartingStep:result", {
+        reason: "forbidden",
+        step: STEP_LOGIN,
+        stepName: this._getStepName(STEP_LOGIN),
+      });
       return STEP_LOGIN;
     }
 
     if (!hasCompletedInitialConfiguration) {
       this.isFirstTimeSetup = true;
 
+      if (isPristineSetup) {
+        const resolvedStep = this.isLoggedIn
+          ? STEP_INTRO
+          : this._resolvePersistedSetupStep(setupState, STEP_INTRO);
+        this._logSetupFlow("determineStartingStep:result", {
+          reason: this.isLoggedIn
+            ? "fresh-setup-pristine-with-stale-login"
+            : "fresh-setup-pristine",
+          step: resolvedStep,
+          stepName: this._getStepName(resolvedStep),
+        });
+        return resolvedStep;
+      }
+
       if (!this.isLoggedIn) {
         if (hasGeneratedKey || hasConfiguredNetwork || activeBootstrapJobId) {
+          this._logSetupFlow("determineStartingStep:result", {
+            reason: "not-logged-in-but-partially-configured",
+            step: STEP_LOGIN,
+            stepName: this._getStepName(STEP_LOGIN),
+          });
           return STEP_LOGIN;
         }
-        return STEP_INTRO;
       }
 
       if (!hasGeneratedKey) {
-        return STEP_GENERATE_KEY;
+        const resolvedStep = this._resolvePersistedSetupStep(
+          setupState,
+          STEP_GENERATE_KEY,
+        );
+        this._logSetupFlow("determineStartingStep:result", {
+          reason: "logged-in-missing-generated-key",
+          step: resolvedStep,
+          stepName: this._getStepName(resolvedStep),
+        });
+        return resolvedStep;
       }
       if (activeBootstrapJobId) {
         this.bootstrapJobId = activeBootstrapJobId;
-        return STEP_BOOTSTRAP;
+        const resolvedStep = this._resolvePersistedSetupStep(
+          setupState,
+          STEP_BOOTSTRAP,
+        );
+        this._logSetupFlow("determineStartingStep:result", {
+          reason: "active-bootstrap-job",
+          step: resolvedStep,
+          stepName: this._getStepName(resolvedStep),
+          bootstrapJobId: activeBootstrapJobId,
+        });
+        return resolvedStep;
       }
       if (!hasConfiguredNetwork) {
-        return STEP_NETWORK;
+        const resolvedStep = this._resolvePersistedSetupStep(
+          setupState,
+          STEP_NETWORK,
+        );
+        this._logSetupFlow("determineStartingStep:result", {
+          reason: "logged-in-missing-network",
+          step: resolvedStep,
+          stepName: this._getStepName(resolvedStep),
+        });
+        return resolvedStep;
       }
+      this._logSetupFlow("determineStartingStep:result", {
+        reason: "initial-config-finished-awaiting-done",
+        step: STEP_DONE,
+        stepName: this._getStepName(STEP_DONE),
+      });
       return STEP_DONE;
     }
 
     // If we're already fully set up, or if we've generated a key, show our login step.
     if (!this.isLoggedIn) {
+      this._logSetupFlow("determineStartingStep:result", {
+        reason: "configured-but-not-logged-in",
+        step: STEP_LOGIN,
+        stepName: this._getStepName(STEP_LOGIN),
+      });
       return STEP_LOGIN;
     }
 
     // Default to login if none of the above conditions are met
+    this._logSetupFlow("determineStartingStep:result", {
+      reason: "configured-and-logged-in",
+      step: STEP_DONE,
+      stepName: this._getStepName(STEP_DONE),
+    });
     return STEP_DONE;
   }
 
@@ -237,13 +512,60 @@ class AppModeApp extends LitElement {
   }
 
   _nextStep = () => {
+    const fromStep = this.activeStepNumber;
     this.isLoggedIn = this.context.store.networkContext.token;
     this.activeStepNumber++;
+    this._logSetupFlow("nextStep", {
+      fromStep,
+      fromStepName: this._getStepName(fromStep),
+      toStep: this.activeStepNumber,
+      toStepName: this._getStepName(this.activeStepNumber),
+      isLoggedIn: this.isLoggedIn,
+    });
   };
 
   _goToStep = (stepNumber) => {
+    const fromStep = this.activeStepNumber;
     this.activeStepNumber = stepNumber;
+    this._logSetupFlow("goToStep", {
+      fromStep,
+      fromStepName: this._getStepName(fromStep),
+      toStep: stepNumber,
+      toStepName: this._getStepName(stepNumber),
+    });
   };
+
+  updated(changedProperties) {
+    if (changedProperties.has("activeStepNumber")) {
+      const previousStep = changedProperties.get("activeStepNumber");
+      if (
+        this.activeStepNumber >= STEP_INTRO &&
+        this.activeStepNumber <= STEP_BOOTSTRAP
+      ) {
+        this._writePersistedSetupStep(
+          this.activeStepNumber,
+          this.setupState?.setupSessionId,
+        );
+      } else if (this.activeStepNumber === STEP_LOGIN && this.setupState) {
+        this._clearPersistedSetupStep();
+      }
+      this._logSetupFlow("activeStepNumber changed", {
+        previousStep,
+        previousStepName:
+          previousStep === undefined ? undefined : this._getStepName(previousStep),
+        nextStep: this.activeStepNumber,
+        nextStepName: this._getStepName(this.activeStepNumber),
+      });
+    }
+
+    if (changedProperties.has("isLoggedIn")) {
+      this._logSetupFlow("isLoggedIn changed", {
+        previous: changedProperties.get("isLoggedIn"),
+        next: this.isLoggedIn,
+        hasToken: !!this.context.store.networkContext.token,
+      });
+    }
+  }
 
   disconnectedCallback() {
     this.mainChannel.removeObserver(this);
@@ -252,6 +574,7 @@ class AppModeApp extends LitElement {
 
   performLogout(e) {
     if (!e.currentTarget.disabled) {
+      this._clearPersistedSetupStep();
       store.updateState({ networkContext: { token: null } });
       window.location.reload();
     }
@@ -360,6 +683,7 @@ class AppModeApp extends LitElement {
                         () =>
                           html`<x-action-system-settings
                             .setupData=${this._setupData}
+                            .onBack=${() => this._goToStep(STEP_INTRO)}
                             .onSuccess=${this._nextStep}
                           ></x-action-system-settings>`,
                       ],
@@ -372,6 +696,7 @@ class AppModeApp extends LitElement {
                             description="Devise a secure password used to encrypt your Dogebox Master Key."
                             retainHash
                             noSubmit
+                            .onBack=${() => this._goToStep(STEP_SYS_SETTINGS)}
                             .onSuccess=${this._nextStep}
                           ></x-action-change-pass>`,
                       ],
@@ -379,6 +704,7 @@ class AppModeApp extends LitElement {
                         STEP_GENERATE_KEY,
                         () =>
                           html`<x-action-create-key
+                            .onBack=${() => this._goToStep(STEP_SET_PASSWORD)}
                             .onSuccess=${this._nextStep}
                           ></x-action-create-key>`,
                       ],
@@ -386,9 +712,9 @@ class AppModeApp extends LitElement {
                         STEP_NETWORK,
                         () =>
                           html`<x-action-select-network
-                            .onSuccess=${async (jobId) => {
+                            .onBack=${() => this._goToStep(STEP_GENERATE_KEY)}
+                            .onSuccess=${(jobId) => {
                               this.bootstrapJobId = jobId;
-                              await asyncTimeout(750);
                               this._nextStep();
                             }}
                             .reflectorToken=${reflectorToken}
@@ -399,6 +725,7 @@ class AppModeApp extends LitElement {
                         () =>
                           html`<x-action-setup-progress
                             .jobId=${this.bootstrapJobId}
+                            .onBack=${() => this._goToStep(STEP_NETWORK)}
                             .onSuccess=${async () => {
                               await asyncTimeout(750);
                               this._nextStep();

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -88,6 +88,7 @@ class AppModeApp extends LitElement {
     isForbidden: { type: Boolean },
     hasLoaded: { type: Boolean },
     bootstrapJobId: { type: String },
+    bootstrapStartError: { type: String },
     installationState: { type: String },
     installationBootMedia: { type: String },
     renderReady: { type: Boolean },
@@ -102,6 +103,7 @@ class AppModeApp extends LitElement {
     this.isFirstTimeSetup = false;
     this.isForbidden = false;
     this.bootstrapJobId = null;
+    this.bootstrapStartError = "";
     this.installationState = "notInstalled";
     this.installationBootMedia = "ro";
     this.hasLoaded = false;
@@ -232,6 +234,7 @@ class AppModeApp extends LitElement {
         STEP_SET_PASSWORD,
         STEP_GENERATE_KEY,
         STEP_NETWORK,
+        STEP_BOOTSTRAP,
       ]);
     }
 
@@ -713,9 +716,18 @@ class AppModeApp extends LitElement {
                         () =>
                           html`<x-action-select-network
                             .onBack=${() => this._goToStep(STEP_GENERATE_KEY)}
+                            .onStart=${() => {
+                              this.bootstrapJobId = "";
+                              this.bootstrapStartError = "";
+                              this._nextStep();
+                            }}
                             .onSuccess=${(jobId) => {
                               this.bootstrapJobId = jobId;
-                              this._nextStep();
+                              this.bootstrapStartError = "";
+                            }}
+                            .onBootstrapStartFailed=${(errorMessage) => {
+                              this.bootstrapJobId = null;
+                              this.bootstrapStartError = errorMessage;
                             }}
                             .reflectorToken=${reflectorToken}
                           ></x-action-select-network>`,
@@ -725,13 +737,14 @@ class AppModeApp extends LitElement {
                         () =>
                           html`<x-action-setup-progress
                             .jobId=${this.bootstrapJobId}
+                            .startErrorMessage=${this.bootstrapStartError}
                             .onBack=${() => this._goToStep(STEP_NETWORK)}
-                            .onSuccess=${async () => {
-                              await asyncTimeout(750);
+                            .onSuccess=${() => {
                               this._nextStep();
                             }}
                             .onFailure=${() => {
                               this.bootstrapJobId = null;
+                              this.bootstrapStartError = "";
                               this._goToStep(STEP_NETWORK);
                             }}
                           ></x-action-setup-progress>`,

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -20,6 +20,7 @@ import "/components/views/action-login/index.js";
 import "/components/views/action-change-pass/index.js";
 import "/components/views/action-create-key/index.js";
 import "/components/views/action-select-network/index.js";
+import "/components/views/action-setup-progress/index.js";
 import "/components/views/action-select-install-location/index.js";
 import "/components/views/action-system-settings/index.js";
 import "/components/views/setup-dislaimer/index.js";
@@ -60,8 +61,9 @@ const STEP_SYS_SETTINGS = 2;
 const STEP_SET_PASSWORD = 3;
 const STEP_GENERATE_KEY = 4;
 const STEP_NETWORK = 5;
-const STEP_DONE = 6;
-const STEP_INSTALL = 7;
+const STEP_BOOTSTRAP = 6;
+const STEP_DONE = 7;
+const STEP_INSTALL = 8;
 
 class AppModeApp extends LitElement {
   static styles = [appModeStyles, navStyles];
@@ -73,6 +75,7 @@ class AppModeApp extends LitElement {
     isFirstTimeSetup: { type: Boolean },
     isForbidden: { type: Boolean },
     hasLoaded: { type: Boolean },
+    bootstrapJobId: { type: String },
     installationState: { type: String },
     installationBootMedia: { type: String },
     renderReady: { type: Boolean },
@@ -86,6 +89,7 @@ class AppModeApp extends LitElement {
     this.setupState = null;
     this.isFirstTimeSetup = false;
     this.isForbidden = false;
+    this.bootstrapJobId = null;
     this.installationState = "notInstalled";
     this.installationBootMedia = "ro";
     this.hasLoaded = false;
@@ -167,6 +171,7 @@ class AppModeApp extends LitElement {
       hasCompletedInitialConfiguration,
       hasGeneratedKey,
       hasConfiguredNetwork,
+      activeBootstrapJobId,
       isForbidden,
     } = setupState;
 
@@ -175,24 +180,22 @@ class AppModeApp extends LitElement {
       return STEP_LOGIN;
     }
 
-    // Handle first-time setup
     if (!hasCompletedInitialConfiguration) {
       this.isFirstTimeSetup = true;
-      return STEP_INTRO;
-    }
 
-    // If we're already fully set up, or if we've generated a key, show our login step.
-    if (
-      !this.isLoggedIn &&
-      (hasCompletedInitialConfiguration || hasGeneratedKey)
-    ) {
-      return STEP_LOGIN;
-    }
+      if (!this.isLoggedIn) {
+        if (hasGeneratedKey || hasConfiguredNetwork || activeBootstrapJobId) {
+          return STEP_LOGIN;
+        }
+        return STEP_INTRO;
+      }
 
-    // If we're logged in, follow the setup sequence
-    if (this.isLoggedIn) {
       if (!hasGeneratedKey) {
         return STEP_GENERATE_KEY;
+      }
+      if (activeBootstrapJobId) {
+        this.bootstrapJobId = activeBootstrapJobId;
+        return STEP_BOOTSTRAP;
       }
       if (!hasConfiguredNetwork) {
         return STEP_NETWORK;
@@ -200,8 +203,13 @@ class AppModeApp extends LitElement {
       return STEP_DONE;
     }
 
+    // If we're already fully set up, or if we've generated a key, show our login step.
+    if (!this.isLoggedIn) {
+      return STEP_LOGIN;
+    }
+
     // Default to login if none of the above conditions are met
-    return STEP_LOGIN;
+    return STEP_DONE;
   }
 
   firstUpdated() {
@@ -231,6 +239,10 @@ class AppModeApp extends LitElement {
   _nextStep = () => {
     this.isLoggedIn = this.context.store.networkContext.token;
     this.activeStepNumber++;
+  };
+
+  _goToStep = (stepNumber) => {
+    this.activeStepNumber = stepNumber;
   };
 
   disconnectedCallback() {
@@ -374,12 +386,28 @@ class AppModeApp extends LitElement {
                         STEP_NETWORK,
                         () =>
                           html`<x-action-select-network
-                            .onSuccess=${async () => {
+                            .onSuccess=${async (jobId) => {
+                              this.bootstrapJobId = jobId;
                               await asyncTimeout(750);
                               this._nextStep();
                             }}
                             .reflectorToken=${reflectorToken}
                           ></x-action-select-network>`,
+                      ],
+                      [
+                        STEP_BOOTSTRAP,
+                        () =>
+                          html`<x-action-setup-progress
+                            .jobId=${this.bootstrapJobId}
+                            .onSuccess=${async () => {
+                              await asyncTimeout(750);
+                              this._nextStep();
+                            }}
+                            .onFailure=${() => {
+                              this.bootstrapJobId = null;
+                              this._goToStep(STEP_NETWORK);
+                            }}
+                          ></x-action-setup-progress>`,
                       ],
                       [
                         STEP_DONE,

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -408,6 +408,7 @@ class AppModeApp extends LitElement {
       return STEP_LOGIN;
     }
 
+    // Handle first-time setup
     if (!hasCompletedInitialConfiguration) {
       this.isFirstTimeSetup = true;
 
@@ -452,6 +453,7 @@ class AppModeApp extends LitElement {
         }
       }
 
+      // If we're logged in, follow the setup sequence.
       if (!hasGeneratedKey) {
         const resolvedStep = this._resolvePersistedSetupStep(
           setupState,

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -12,6 +12,7 @@ class DynamicForm extends LitElement {
       values: { type: Object },
       fields: { type: Object },
       onSubmit: { type: Object },
+      footerStart: { type: Object },
       requireCommit: { type: Boolean },
       markModifiedFields: { type: Boolean },
       allowDiscardChanges: { type: Boolean },
@@ -33,6 +34,7 @@ class DynamicForm extends LitElement {
     bindToClass(methods, this);
     this.values = {};
     this.fields = {};
+    this.footerStart = null;
     this.requireCommit = false;
     this.markModifiedFields = false;
     this.allowDiscardChanges = false;

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -12,7 +12,8 @@ class DynamicForm extends LitElement {
       values: { type: Object },
       fields: { type: Object },
       onSubmit: { type: Object },
-      footerStart: { type: Object },
+      onBack: { type: Object },
+      backLabel: { type: String },
       requireCommit: { type: Boolean },
       markModifiedFields: { type: Boolean },
       allowDiscardChanges: { type: Boolean },
@@ -34,7 +35,8 @@ class DynamicForm extends LitElement {
     bindToClass(methods, this);
     this.values = {};
     this.fields = {};
-    this.footerStart = null;
+    this.onBack = undefined;
+    this.backLabel = "Back";
     this.requireCommit = false;
     this.markModifiedFields = false;
     this.allowDiscardChanges = false;

--- a/src/components/common/dynamic-form/renders/form.js
+++ b/src/components/common/dynamic-form/renders/form.js
@@ -132,8 +132,12 @@ export function _generateFormControls(options = {}) {
   const submitLabelSuccess = options.submitLabelSuccess || "";
   return html`
     <div class="footer-controls">
-      ${this.footerStart
-        ? html`<div class="footer-actions-start">${this.footerStart}</div>`
+      ${this.onBack
+        ? html`
+            <sl-button variant="default" @click=${() => this.onBack?.()}>
+              ${this.backLabel}
+            </sl-button>
+          `
         : nothing}
 
       <div class="footer-actions-end">

--- a/src/components/common/dynamic-form/renders/form.js
+++ b/src/components/common/dynamic-form/renders/form.js
@@ -128,35 +128,56 @@ export function _generateErrorField(field) {
 
 export function _generateFormControls(options = {}) {
   const changeCount = this[`_form_${options.formId}_count`];
+  const submitLabel = options.submitLabel || "Save";
+  const submitLabelSuccess = options.submitLabelSuccess || "";
   return html`
     <div class="footer-controls">
-      ${this.allowDiscardChanges && changeCount
-        ? html`
-            <sl-button
-              variant="text"
-              id="${options.formId}__reset_button"
-              @click=${this._handleDiscardChanges}
-              class=${this.theme}
-            >
-              Discard changes
-            </sl-button>
-          `
+      ${this.footerStart
+        ? html`<div class="footer-actions-start">${this.footerStart}</div>`
         : nothing}
 
-      <sl-button
-        id="${options.formId}__save_button"
-        variant="primary"
-        type="submit"
-        class=${this.theme}
-        ?loading=${this._loading}
-        ?disabled=${!changeCount || this._celebrate}
-        form=${options.formId}
-      >
-        ${this._celebrate ? html`
-          <sl-icon name="check-lg" slot=${options.submitLabelSuccess ? "prefix" : ""}></sl-icon>
-          ${options.submitLabelSuccess}
-          ` : (options.submitLabel || "Save")}
-      </sl-button>
+      <div class="footer-actions-end">
+        ${this.allowDiscardChanges && changeCount
+          ? html`
+              <sl-button
+                variant="text"
+                id="${options.formId}__reset_button"
+                @click=${this._handleDiscardChanges}
+                class=${this.theme}
+              >
+                Discard changes
+              </sl-button>
+            `
+          : nothing}
+
+        <sl-button
+          id="${options.formId}__save_button"
+          variant="primary"
+          type="submit"
+          class=${this.theme}
+          ?loading=${this._loading}
+          ?disabled=${!changeCount || this._celebrate}
+          form=${options.formId}
+        >
+          ${this._celebrate
+            ? submitLabelSuccess
+              ? html`
+                  <sl-icon name="check-lg" slot="prefix"></sl-icon>
+                  ${submitLabelSuccess}
+                `
+              : html`
+                  <span class="submit-success-state">
+                    <span class="submit-success-icon" aria-hidden="true">
+                      <sl-icon name="check-lg"></sl-icon>
+                    </span>
+                    <span class="submit-success-placeholder">
+                      ${submitLabel}
+                    </span>
+                  </span>
+                `
+            : submitLabel}
+        </sl-button>
+      </div>
     </div>
   `;
 }

--- a/src/components/common/dynamic-form/styles.js
+++ b/src/components/common/dynamic-form/styles.js
@@ -71,7 +71,36 @@ export const styles = css`
   /* Footer buttons (submit, discard etc) */
   .footer-controls {
     display: flex;
+    align-items: center;
     justify-content: var(--submit-btn-anchor, flex-end);
+    gap: 0.75rem;
+  }
+
+  .footer-actions-end {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-left: auto;
+  }
+
+  .submit-success-state {
+    display: inline-grid;
+    place-items: center;
+  }
+
+  .submit-success-icon,
+  .submit-success-placeholder {
+    grid-area: 1 / 1;
+  }
+
+  .submit-success-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .submit-success-placeholder {
+    visibility: hidden;
   }
 
   .footer-controls sl-button.discard-button::part(base) {

--- a/src/components/layouts/recovery/renders/nav.js
+++ b/src/components/layouts/recovery/renders/nav.js
@@ -155,6 +155,7 @@ export function renderNav(isFirstTimeSetup) {
     { name: "pass", label: "Set Password" },
     { name: "key", label: "Create Key" },
     { name: "connect", label: "Connect" },
+    { name: "bootstrap", label: "Setting Up" },
   ];
 
   return html`
@@ -180,7 +181,7 @@ export function renderNav(isFirstTimeSetup) {
             </div>
           `,
         )}
-        ${this.activeStepNumber === 6
+        ${this.activeStepNumber === 7
           ? html`
               <div class="step mobile-only" data-completed-step>
                 <sl-button size="small" circle>✓</sl-button>

--- a/src/components/views/action-change-pass/index.js
+++ b/src/components/views/action-change-pass/index.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import { postChangePass } from "/api/password/change-pass.js";
 import { createAlert } from "/components/common/alert.js";
 import { hash } from "/utils/hash.js"
@@ -239,13 +239,7 @@ class ChangePassView extends LitElement {
           <dynamic-form
             .fields=${this._changePassFields}
             .onSubmit=${this._attemptChangePass}
-            .footerStart=${this.onBack
-              ? html`
-                  <sl-button variant="default" @click=${this.handleBackClick}>
-                    Back
-                  </sl-button>
-                `
-              : nothing}
+            .onBack=${this.onBack ? this.handleBackClick : undefined}
             requireCommit
             theme="purple"
           >

--- a/src/components/views/action-change-pass/index.js
+++ b/src/components/views/action-change-pass/index.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import { postChangePass } from "/api/password/change-pass.js";
 import { createAlert } from "/components/common/alert.js";
 import { hash } from "/utils/hash.js"
@@ -31,6 +31,7 @@ class ChangePassView extends LitElement {
     h1 {
       font-family: "Comic Neue", sans-serif;
     }
+
   `;
 
   static get properties() {
@@ -44,6 +45,7 @@ class ChangePassView extends LitElement {
       refreshAfterChange: { type: Boolean },
       retainHash: { type: Boolean },
       noSubmit: { type: Boolean },
+      onBack: { type: Object },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
     };
@@ -59,6 +61,7 @@ class ChangePassView extends LitElement {
     this.refreshAfterChange = false;
     this.retainHash = false;
     this.noSubmit = false;
+    this.onBack = null;
     this.fieldDefaults = {};
     this._server_fault = false;
     this._invalid_creds = false;
@@ -217,6 +220,12 @@ class ChangePassView extends LitElement {
     }
   }
 
+  handleBackClick = () => {
+    if (this.onBack) {
+      this.onBack();
+    }
+  }
+
   render() {
     return html`
       <div class="page">
@@ -230,6 +239,13 @@ class ChangePassView extends LitElement {
           <dynamic-form
             .fields=${this._changePassFields}
             .onSubmit=${this._attemptChangePass}
+            .footerStart=${this.onBack
+              ? html`
+                  <sl-button variant="default" @click=${this.handleBackClick}>
+                    Back
+                  </sl-button>
+                `
+              : nothing}
             requireCommit
             theme="purple"
           >

--- a/src/components/views/action-create-key/index.js
+++ b/src/components/views/action-create-key/index.js
@@ -34,6 +34,7 @@ class CreateKey extends LitElement {
   static get properties() {
     return {
       showSuccessAlert: { type: Boolean },
+      onBack: { type: Object },
       _authenticationRequired: { type: Boolean },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
@@ -50,6 +51,7 @@ class CreateKey extends LitElement {
   constructor() {
     super();
     this._authenticationRequired = false;
+    this.onBack = null;
     this._server_fault = false;
     this._invalid_creds = false;
     this._form = null;
@@ -164,6 +166,12 @@ class CreateKey extends LitElement {
 
   _handleContinueClick() {
     this.handleSuccess();
+  }
+
+  handleBackClick = () => {
+    if (this.onBack) {
+      this.onBack();
+    }
   }
 
   render() {
@@ -310,7 +318,17 @@ class CreateKey extends LitElement {
               ${!this._keyListLoading && !hasMasterKey
                 ? html`
                     ${emptyKey}
-                    <div style="text-align: right;">
+                    <div style="display: flex; justify-content: space-between; gap: 1rem;">
+                      ${this.onBack
+                        ? html`
+                            <sl-button
+                              variant="default"
+                              @click=${this.handleBackClick}
+                            >
+                              Back
+                            </sl-button>
+                          `
+                        : html`<span></span>`}
                       <sl-button
                         id="GenKeyBtn"
                         @click=${this.handleGenKeyClick}
@@ -325,7 +343,17 @@ class CreateKey extends LitElement {
                 ? html`
                     ${masterKeyEl}
                     <sl-divider></sl-divider>
-                    <div style="text-align: right;">
+                    <div style="display: flex; justify-content: space-between; gap: 1rem;">
+                      ${this.onBack
+                        ? html`
+                            <sl-button
+                              variant="default"
+                              @click=${this.handleBackClick}
+                            >
+                              Back
+                            </sl-button>
+                          `
+                        : html`<span></span>`}
                       <sl-button
                         @click=${this._handleContinueClick}
                         class="pink"

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -305,6 +305,7 @@ class SelectNetwork extends LitElement {
     // TODO: move this into post-network flow.
     const finalSystemBootstrap = await postSetupBootstrap({
       initialSSHKey: state["ssh-key"],
+      // Reflector data is submitted here so bootstrap can persist it for post-reboot submission.
       reflectorToken: this.reflectorToken,
       reflectorHost: store.networkContext.reflectorHost,
       useFoundationPupBinaryCache: store.setupContext.useFoundationPupBinaryCache,
@@ -314,6 +315,8 @@ class SelectNetwork extends LitElement {
       return { errorHandled: true };
     });
 
+    // Bootstrap start errors are handled either by the catch block above or by
+    // the missing-jobId guard below.
     if (finalSystemBootstrap?.errorHandled) {
       dynamicFormInstance.retainChanges(); // stops spinner
       return;

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -297,11 +297,8 @@ class SelectNetwork extends LitElement {
 
     await this.handleStart();
 
-    // temp: wait, because this needs to move to being an async call inside dogeboxd
-    //       so that the putNetwork above can "complete".
+    // Give the requested network change a moment to settle before starting bootstrap.
     await asyncTimeout(5000);
-
-    // temp: also call our final initialisation API here.
     // TODO: move this into post-network flow.
     const finalSystemBootstrap = await postSetupBootstrap({
       initialSSHKey: state["ssh-key"],

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -42,6 +42,7 @@ class SelectNetwork extends LitElement {
     return {
       showSuccessAlert: { type: Boolean },
       reflectorToken: { type: String },
+      onSuccess: { type: Object },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
       _setNetworkFields: { type: Object },
@@ -296,30 +297,24 @@ class SelectNetwork extends LitElement {
     // TODO: move this into post-network flow.
     const finalSystemBootstrap = await postSetupBootstrap({
       initialSSHKey: state["ssh-key"],
-      // Temporarily don't submit reflectorToken until the service is up and running.
       reflectorToken: this.reflectorToken,
       reflectorHost: store.networkContext.reflectorHost,
       useFoundationPupBinaryCache: store.setupContext.useFoundationPupBinaryCache,
       useFoundationOSBinaryCache: store.setupContext.useFoundationOSBinaryCache
-    }).catch(() => {
-      console.log("bootstrap called but no response returned");
+    }).catch((error) => {
+      this.handleBootstrapError(error);
+      return null;
     });
 
-    // if (!finalSystemBootstrap) {
-    //   dynamicFormInstance.retainChanges(); // stops spinner
-    //   return;
-    // }
-
-    // if (finalSystemBootstrap.error) {
-    //   dynamicFormInstance.retainChanges(); // stops spinner
-    //   this.handleError(finalSystemBootstrap.error);
-    //   return;
-    // }
+    if (!finalSystemBootstrap?.jobId) {
+      dynamicFormInstance.retainChanges(); // stops spinner
+      return;
+    }
 
     // Handle success
     dynamicFormInstance.retainChanges(); // stops spinner
     dynamicFormInstance.toggleCelebrate();
-    await this.handleSuccess();
+    await this.handleSuccess(finalSystemBootstrap.jobId);
   };
 
   handleFault = (fault) => {
@@ -339,7 +334,22 @@ class SelectNetwork extends LitElement {
     createAlert("danger", message, "emoji-frown", null, action, new Error(err));
   }
 
-  async handleSuccess() {
+  handleBootstrapError(err) {
+    const detail = err?.message ?? "No details were returned by the server.";
+    createAlert(
+      "danger",
+      [
+        "Setup could not be started.",
+        "Please review your settings and try again.",
+      ],
+      "emoji-frown",
+      null,
+      { text: "View details" },
+      new Error(detail),
+    );
+  }
+
+  async handleSuccess(jobId) {
     if (this.showSuccessAlert) {
       createAlert(
         "success",
@@ -349,7 +359,7 @@ class SelectNetwork extends LitElement {
       );
     }
     if (this.onSuccess) {
-      await this.onSuccess();
+      await this.onSuccess(jobId);
     }
   }
 

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -43,7 +43,9 @@ class SelectNetwork extends LitElement {
       showSuccessAlert: { type: Boolean },
       reflectorToken: { type: String },
       onBack: { type: Object },
+      onStart: { type: Object },
       onSuccess: { type: Object },
+      onBootstrapStartFailed: { type: Object },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
       _setNetworkFields: { type: Object },
@@ -56,6 +58,8 @@ class SelectNetwork extends LitElement {
     super();
     this._form = null;
     this.onBack = null;
+    this.onStart = null;
+    this.onBootstrapStartFailed = null;
     this._server_fault = false;
     this._invalid_creds = false;
     this._setNetworkFields = {};
@@ -291,6 +295,8 @@ class SelectNetwork extends LitElement {
       return;
     }
 
+    await this.handleStart();
+
     // temp: wait, because this needs to move to being an async call inside dogeboxd
     //       so that the putNetwork above can "complete".
     await asyncTimeout(5000);
@@ -305,11 +311,19 @@ class SelectNetwork extends LitElement {
       useFoundationOSBinaryCache: store.setupContext.useFoundationOSBinaryCache
     }).catch((error) => {
       this.handleBootstrapError(error);
-      return null;
+      return { errorHandled: true };
     });
+
+    if (finalSystemBootstrap?.errorHandled) {
+      dynamicFormInstance.retainChanges(); // stops spinner
+      return;
+    }
 
     if (!finalSystemBootstrap?.jobId) {
       dynamicFormInstance.retainChanges(); // stops spinner
+      this.handleBootstrapStartFailure(
+        "Setup could not be started. Please review your settings and try again.",
+      );
       return;
     }
 
@@ -348,6 +362,21 @@ class SelectNetwork extends LitElement {
       { text: "View details" },
       new Error(detail),
     );
+    this.handleBootstrapStartFailure(
+      `Setup could not be started. ${detail}`,
+    );
+  }
+
+  handleBootstrapStartFailure(message) {
+    if (this.onBootstrapStartFailed) {
+      this.onBootstrapStartFailed(message);
+    }
+  }
+
+  async handleStart() {
+    if (this.onStart) {
+      await this.onStart();
+    }
   }
 
   async handleSuccess(jobId) {

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import { getNetworks } from "/api/network/get-networks.js";
 import { putNetwork } from "/api/network/set-network.js";
 import { postSetupBootstrap } from "/api/system/post-bootstrap.js";
@@ -42,6 +42,7 @@ class SelectNetwork extends LitElement {
     return {
       showSuccessAlert: { type: Boolean },
       reflectorToken: { type: String },
+      onBack: { type: Object },
       onSuccess: { type: Object },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
@@ -54,6 +55,7 @@ class SelectNetwork extends LitElement {
   constructor() {
     super();
     this._form = null;
+    this.onBack = null;
     this._server_fault = false;
     this._invalid_creds = false;
     this._setNetworkFields = {};
@@ -313,7 +315,6 @@ class SelectNetwork extends LitElement {
 
     // Handle success
     dynamicFormInstance.retainChanges(); // stops spinner
-    dynamicFormInstance.toggleCelebrate();
     await this.handleSuccess(finalSystemBootstrap.jobId);
   };
 
@@ -363,6 +364,12 @@ class SelectNetwork extends LitElement {
     }
   }
 
+  handleBackClick = () => {
+    if (this.onBack) {
+      this.onBack();
+    }
+  }
+
   _renderIcon(name) {
     return html`<sl-icon name=${name}></sl-icon>`;
   }
@@ -394,6 +401,13 @@ class SelectNetwork extends LitElement {
               .fields=${this._setNetworkFields}
               .values=${this._setNetworkValues}
               .onSubmit=${this._attemptSetNetwork}
+              .footerStart=${this.onBack
+                ? html`
+                    <sl-button variant="default" @click=${this.handleBackClick}>
+                      Back
+                    </sl-button>
+                  `
+                : nothing}
               requireCommit
               theme="yellow"
               style="--submit-btn-width: auto; --submit-btn-anchor: end;"

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -433,13 +433,7 @@ class SelectNetwork extends LitElement {
               .fields=${this._setNetworkFields}
               .values=${this._setNetworkValues}
               .onSubmit=${this._attemptSetNetwork}
-              .footerStart=${this.onBack
-                ? html`
-                    <sl-button variant="default" @click=${this.handleBackClick}>
-                      Back
-                    </sl-button>
-                  `
-                : nothing}
+              .onBack=${this.onBack ? this.handleBackClick : undefined}
               requireCommit
               theme="yellow"
               style="--submit-btn-width: auto; --submit-btn-anchor: end;"

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -1,0 +1,216 @@
+import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { store } from "/state/store.js";
+import { StoreSubscriber } from "/state/subscribe.js";
+import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+
+import "/components/views/x-log-viewer/index.js";
+
+class SetupProgress extends LitElement {
+  static properties = {
+    jobId: { type: String },
+    onSuccess: { type: Object },
+    onFailure: { type: Object },
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      font-family: "Comic Neue", sans-serif;
+    }
+
+    .page {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .banner {
+      border-radius: 16px;
+      padding: 1.5rem;
+      color: white;
+      background-color: var(--sl-color-yellow-500);
+      background-image: linear-gradient(
+        to bottom right,
+        var(--sl-color-yellow-500),
+        var(--sl-color-amber-600)
+      );
+    }
+
+    .banner h1,
+    .banner p {
+      margin: 0;
+    }
+
+    .banner h1 {
+      line-height: 1.1;
+      margin-bottom: 0.75rem;
+    }
+
+    .status-card {
+      border: 1px solid var(--sl-panel-border-color);
+      border-radius: 16px;
+      padding: 1rem;
+      background: var(--sl-color-neutral-0);
+    }
+
+    .status-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .status-copy h2,
+    .status-copy p {
+      margin: 0;
+    }
+
+    .status-copy h2 {
+      font-size: 1.1rem;
+      margin-bottom: 0.35rem;
+    }
+
+    .status-copy p {
+      color: var(--sl-color-neutral-600);
+      font-family: sans-serif;
+    }
+
+    .error-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 1rem;
+    }
+
+    x-log-viewer {
+      --log-viewer-height: 360px;
+      --log-footer-height: 56px;
+      border-radius: 12px;
+      overflow: hidden;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.jobId = "";
+    this.onSuccess = null;
+    this.onFailure = null;
+    this.context = new StoreSubscriber(this, store);
+    this._completionHandled = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    jobWebSocket.connect();
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has("jobId")) {
+      this._completionHandled = false;
+    }
+
+    const job = this._job;
+    if (!job || this._completionHandled) {
+      return;
+    }
+
+    if (job.status === "completed") {
+      this._completionHandled = true;
+      this.onSuccess && this.onSuccess();
+    }
+  }
+
+  get _job() {
+    return store.jobsContext.jobs.find((job) => job.id === this.jobId) ?? null;
+  }
+
+  get _statusVariant() {
+    const status = this._job?.status;
+    if (status === "failed" || status === "cancelled") return "danger";
+    if (status === "completed") return "success";
+    return "warning";
+  }
+
+  get _statusLabel() {
+    const status = this._job?.status;
+    if (status === "queued") return "Queued";
+    if (status === "in_progress") return "In Progress";
+    if (status === "failed") return "Failed";
+    if (status === "cancelled") return "Cancelled";
+    if (status === "completed") return "Completed";
+    return "Preparing";
+  }
+
+  get _statusMessage() {
+    const job = this._job;
+    if (!this.jobId) {
+      return "Waiting for the setup job to start.";
+    }
+    if (!job) {
+      return "Connecting to the setup job and loading logs.";
+    }
+    if (job.status === "failed" || job.status === "cancelled") {
+      return job.errorMessage || "Setup failed. Review the logs and try again.";
+    }
+    if (job.status === "completed") {
+      return "Setup finished successfully. Continuing to the next step.";
+    }
+    return job.summaryMessage || "Your Dogebox is applying the selected settings.";
+  }
+
+  handleBackClick = () => {
+    this.onFailure && this.onFailure();
+  };
+
+  render() {
+    const job = this._job;
+    const isFailed = job?.status === "failed" || job?.status === "cancelled";
+
+    return html`
+      <div class="page">
+        <div class="banner">
+          <h1>Setting up your Dogebox</h1>
+          <p>
+            This can take several minutes while Dogebox applies your network and
+            system settings.
+          </p>
+        </div>
+
+        <div class="status-card">
+          <div class="status-head">
+            <div class="status-copy">
+              <h2>${job?.displayName || "Initial Setup"}</h2>
+              <p>${this._statusMessage}</p>
+            </div>
+            <sl-tag variant=${this._statusVariant} size="large">
+              ${this._statusLabel}
+            </sl-tag>
+          </div>
+
+          ${job
+            ? html`
+                <x-log-viewer .jobId=${this.jobId}></x-log-viewer>
+              `
+            : html`
+                <sl-alert variant="warning" open>
+                  <sl-icon slot="icon" name="hourglass-split"></sl-icon>
+                  Waiting for the setup log stream.
+                </sl-alert>
+              `}
+
+          ${isFailed
+            ? html`
+                <div class="error-actions">
+                  <sl-button variant="primary" @click=${this.handleBackClick}>
+                    Go Back
+                  </sl-button>
+                </div>
+              `
+            : ""}
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define("x-action-setup-progress", SetupProgress);

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -8,6 +8,7 @@ import "/components/views/x-log-viewer/index.js";
 class SetupProgress extends LitElement {
   static properties = {
     jobId: { type: String },
+    onBack: { type: Object },
     onSuccess: { type: Object },
     onFailure: { type: Object },
     _failed: { type: Boolean },
@@ -87,6 +88,7 @@ class SetupProgress extends LitElement {
   constructor() {
     super();
     this.jobId = "";
+    this.onBack = null;
     this.onSuccess = null;
     this.onFailure = null;
     this._failed = false;
@@ -139,7 +141,12 @@ class SetupProgress extends LitElement {
   }
 
   handleBackClick = () => {
-    this.onFailure && this.onFailure();
+    if (this._failed) {
+      this.onFailure && this.onFailure();
+      return;
+    }
+
+    this.onBack && this.onBack();
   };
 
   render() {
@@ -166,7 +173,15 @@ class SetupProgress extends LitElement {
                 </sl-button>
               </div>
             `
-          : nothing}
+          : this.onBack
+            ? html`
+                <div style="display: flex; justify-content: flex-start;">
+                  <sl-button variant="default" @click=${this.handleBackClick}>
+                    Back
+                  </sl-button>
+                </div>
+              `
+            : nothing}
       </div>
     `;
   }

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -8,6 +8,7 @@ import "/components/views/x-log-viewer/index.js";
 class SetupProgress extends LitElement {
   static properties = {
     jobId: { type: String },
+    startErrorMessage: { type: String },
     onBack: { type: Object },
     onSuccess: { type: Object },
     onFailure: { type: Object },
@@ -88,6 +89,7 @@ class SetupProgress extends LitElement {
   constructor() {
     super();
     this.jobId = "";
+    this.startErrorMessage = "";
     this.onBack = null;
     this.onSuccess = null;
     this.onFailure = null;
@@ -140,8 +142,16 @@ class SetupProgress extends LitElement {
     return store.jobsContext.jobs.find((job) => job.id === this.jobId) ?? null;
   }
 
+  get _isFailed() {
+    return Boolean(this.startErrorMessage) || this._failed;
+  }
+
+  get _activeErrorMessage() {
+    return this.startErrorMessage || this._errorMessage;
+  }
+
   handleBackClick = () => {
-    if (this._failed) {
+    if (this._isFailed) {
       this.onFailure && this.onFailure();
       return;
     }
@@ -155,19 +165,24 @@ class SetupProgress extends LitElement {
         <div class="banner">
           <h1>Setting up your Dogebox</h1>
           <p>
-            This can take several minutes while Dogebox applies your network and
-            system settings.
+            ${this.jobId
+              ? "This can take several minutes while Dogebox applies your network and system settings."
+              : "Setup is starting now. Logs will appear here as soon as the backend begins streaming them."}
           </p>
         </div>
 
         <div class="log-wrap">
-          <x-log-viewer .jobId=${this.jobId} ?reconnect=${true}></x-log-viewer>
+          <x-log-viewer
+            .jobId=${this.jobId}
+            ?connecting=${!this.jobId && !this._isFailed}
+            ?reconnect=${true}
+          ></x-log-viewer>
         </div>
 
-        ${this._failed
+        ${this._isFailed
           ? html`
               <div class="error-bar">
-                <p>${this._errorMessage}</p>
+                <p>${this._activeErrorMessage}</p>
                 <sl-button variant="primary" @click=${this.handleBackClick}>
                   Go Back
                 </sl-button>

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -80,7 +80,7 @@ class SetupProgress extends LitElement {
 
     .error-bar p {
       margin: 0;
-      color: var(--sl-color-danger-500);
+      color: white;
       font-family: sans-serif;
       font-size: 0.9rem;
     }
@@ -184,7 +184,7 @@ class SetupProgress extends LitElement {
               <div class="error-bar">
                 <p>${this._activeErrorMessage}</p>
                 <sl-button variant="primary" @click=${this.handleBackClick}>
-                  Go Back
+                  Back
                 </sl-button>
               </div>
             `

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { jobWebSocket } from "/controllers/sockets/job-channel.js";
@@ -10,6 +10,8 @@ class SetupProgress extends LitElement {
     jobId: { type: String },
     onSuccess: { type: Object },
     onFailure: { type: Object },
+    _failed: { type: Boolean },
+    _errorMessage: { type: String },
   };
 
   static styles = css`
@@ -28,12 +30,14 @@ class SetupProgress extends LitElement {
       border-radius: 16px;
       padding: 1.5rem;
       color: white;
-      background-color: var(--sl-color-yellow-500);
+      background-color: var(--sl-color-cyan-600);
       background-image: linear-gradient(
         to bottom right,
-        var(--sl-color-yellow-500),
-        var(--sl-color-amber-600)
+        var(--sl-color-cyan-600),
+        var(--sl-color-sky-500)
       );
+      position: relative;
+      overflow: hidden;
     }
 
     .banner h1,
@@ -46,47 +50,37 @@ class SetupProgress extends LitElement {
       margin-bottom: 0.75rem;
     }
 
-    .status-card {
-      border: 1px solid var(--sl-panel-border-color);
-      border-radius: 16px;
-      padding: 1rem;
-      background: var(--sl-color-neutral-0);
+    .banner p {
+      line-height: 1.5;
+      font-family: unset;
     }
 
-    .status-head {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      margin-bottom: 0.75rem;
-    }
-
-    .status-copy h2,
-    .status-copy p {
-      margin: 0;
-    }
-
-    .status-copy h2 {
-      font-size: 1.1rem;
-      margin-bottom: 0.35rem;
-    }
-
-    .status-copy p {
-      color: var(--sl-color-neutral-600);
-      font-family: sans-serif;
-    }
-
-    .error-actions {
-      display: flex;
-      justify-content: flex-end;
-      margin-top: 1rem;
+    .log-wrap {
+      border-radius: 12px;
+      overflow: hidden;
     }
 
     x-log-viewer {
-      --log-viewer-height: 360px;
+      --log-viewer-height: 420px;
       --log-footer-height: 56px;
+    }
+
+    .error-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.75rem 1rem;
       border-radius: 12px;
-      overflow: hidden;
+      background: rgba(255, 107, 107, 0.1);
+      border: 1px solid var(--sl-color-danger-400);
+    }
+
+    .error-bar p {
+      margin: 0;
+      color: var(--sl-color-danger-500);
+      font-family: sans-serif;
+      font-size: 0.9rem;
     }
   `;
 
@@ -95,6 +89,8 @@ class SetupProgress extends LitElement {
     this.jobId = "";
     this.onSuccess = null;
     this.onFailure = null;
+    this._failed = false;
+    this._errorMessage = "";
     this.context = new StoreSubscriber(this, store);
     this._completionHandled = false;
   }
@@ -102,11 +98,22 @@ class SetupProgress extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     jobWebSocket.connect();
+    this._keepAlive = setInterval(() => {
+      if (this._completionHandled || this._failed) return;
+      jobWebSocket.connect();
+    }, 10000);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearInterval(this._keepAlive);
   }
 
   updated(changedProperties) {
     if (changedProperties.has("jobId")) {
       this._completionHandled = false;
+      this._failed = false;
+      this._errorMessage = "";
     }
 
     const job = this._job;
@@ -118,44 +125,17 @@ class SetupProgress extends LitElement {
       this._completionHandled = true;
       this.onSuccess && this.onSuccess();
     }
+
+    if (job.status === "failed" || job.status === "cancelled") {
+      this._completionHandled = true;
+      this._failed = true;
+      this._errorMessage =
+        job.errorMessage || "Setup failed. Review the logs and try again.";
+    }
   }
 
   get _job() {
     return store.jobsContext.jobs.find((job) => job.id === this.jobId) ?? null;
-  }
-
-  get _statusVariant() {
-    const status = this._job?.status;
-    if (status === "failed" || status === "cancelled") return "danger";
-    if (status === "completed") return "success";
-    return "warning";
-  }
-
-  get _statusLabel() {
-    const status = this._job?.status;
-    if (status === "queued") return "Queued";
-    if (status === "in_progress") return "In Progress";
-    if (status === "failed") return "Failed";
-    if (status === "cancelled") return "Cancelled";
-    if (status === "completed") return "Completed";
-    return "Preparing";
-  }
-
-  get _statusMessage() {
-    const job = this._job;
-    if (!this.jobId) {
-      return "Waiting for the setup job to start.";
-    }
-    if (!job) {
-      return "Connecting to the setup job and loading logs.";
-    }
-    if (job.status === "failed" || job.status === "cancelled") {
-      return job.errorMessage || "Setup failed. Review the logs and try again.";
-    }
-    if (job.status === "completed") {
-      return "Setup finished successfully. Continuing to the next step.";
-    }
-    return job.summaryMessage || "Your Dogebox is applying the selected settings.";
   }
 
   handleBackClick = () => {
@@ -163,9 +143,6 @@ class SetupProgress extends LitElement {
   };
 
   render() {
-    const job = this._job;
-    const isFailed = job?.status === "failed" || job?.status === "cancelled";
-
     return html`
       <div class="page">
         <div class="banner">
@@ -176,38 +153,20 @@ class SetupProgress extends LitElement {
           </p>
         </div>
 
-        <div class="status-card">
-          <div class="status-head">
-            <div class="status-copy">
-              <h2>${job?.displayName || "Initial Setup"}</h2>
-              <p>${this._statusMessage}</p>
-            </div>
-            <sl-tag variant=${this._statusVariant} size="large">
-              ${this._statusLabel}
-            </sl-tag>
-          </div>
-
-          ${job
-            ? html`
-                <x-log-viewer .jobId=${this.jobId}></x-log-viewer>
-              `
-            : html`
-                <sl-alert variant="warning" open>
-                  <sl-icon slot="icon" name="hourglass-split"></sl-icon>
-                  Waiting for the setup log stream.
-                </sl-alert>
-              `}
-
-          ${isFailed
-            ? html`
-                <div class="error-actions">
-                  <sl-button variant="primary" @click=${this.handleBackClick}>
-                    Go Back
-                  </sl-button>
-                </div>
-              `
-            : ""}
+        <div class="log-wrap">
+          <x-log-viewer .jobId=${this.jobId} ?reconnect=${true}></x-log-viewer>
         </div>
+
+        ${this._failed
+          ? html`
+              <div class="error-bar">
+                <p>${this._errorMessage}</p>
+                <sl-button variant="primary" @click=${this.handleBackClick}>
+                  Go Back
+                </sl-button>
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -175,7 +175,7 @@ class SetupProgress extends LitElement {
           <x-log-viewer
             .jobId=${this.jobId}
             ?connecting=${!this.jobId && !this._isFailed}
-            ?reconnect=${true}
+            ?autoReconnect=${true}
           ></x-log-viewer>
         </div>
 

--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -51,20 +51,29 @@ class SystemSettings extends LitElement {
       display: flex;
       flex-direction: row;
       align-items: center;
-      justify-content: flex-end;
+      justify-content: flex-start;
       gap: 1em;
       margin-bottom: 2em;
+    }
+
+    .action-wrap-end {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 1em;
+      margin-left: auto;
     }
 
     h4 { margin: 0.5em 0; display: flex; align-items: center; }
 
     .next-button {
-      margin-top: 2em;
+      margin-top: 0;
     }
   `];
 
   static get properties() {
     return {
+      onBack: { type: Object },
       _loading: { type: Boolean },
       _inflight: { type: Boolean },
       _keymaps: { type: Array },
@@ -80,6 +89,7 @@ class SystemSettings extends LitElement {
 
   constructor() {
     super();
+    this.onBack = null;
     this._keymaps = [];
     this._timezones = [];
     this._disks = [];
@@ -242,6 +252,12 @@ class SystemSettings extends LitElement {
     this._confirmation_checked = e.target.checked;
   }
 
+  handleBackClick = () => {
+    if (this.onBack) {
+      this.onBack();
+    }
+  }
+
   render() {
     if (this._loading) {
       return html`<sl-spinner></sl-spinner>`;
@@ -382,19 +398,32 @@ class SystemSettings extends LitElement {
           </sl-alert>
 
           <div class="action-wrap">
-            ${this._changes.disk && !this._is_boot_media ? html`
-              <sl-checkbox @sl-change=${this.handleCheckboxChange}>I understand</sl-checkbox>
-              `: nothing 
-            }
+            ${this.onBack
+              ? html`
+                  <sl-button
+                    variant="default"
+                    ?disabled=${this._inflight}
+                    @click=${this.handleBackClick}
+                  >
+                    Back
+                  </sl-button>
+                `
+              : nothing}
+            <div class="action-wrap-end">
+              ${this._changes.disk && !this._is_boot_media ? html`
+                <sl-checkbox @sl-change=${this.handleCheckboxChange}>I understand</sl-checkbox>
+                `: nothing 
+              }
 
-            <sl-button
-              class="next-button"
-              variant="primary"
-              ?disabled=${this._inflight || (this._changes.disk && !this._is_boot_media && !this._confirmation_checked)}
-              ?loading=${this._inflight}
-              @click=${this._attemptSubmit}
-              >Next</sl-button
-            >
+              <sl-button
+                class="next-button"
+                variant="primary"
+                ?disabled=${this._inflight || (this._changes.disk && !this._is_boot_media && !this._confirmation_checked)}
+                ?loading=${this._inflight}
+                @click=${this._attemptSubmit}
+                >Next</sl-button
+              >
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -15,6 +15,7 @@ class LogViewer extends LitElement {
       closing: { type: Boolean, reflect: true },
       animateOpen: { type: Boolean },
       opening: { type: Boolean, reflect: true },
+      reconnect: { type: Boolean },
     };
   }
 
@@ -26,14 +27,19 @@ class LogViewer extends LitElement {
     this.isConnected = false;
     this.wsClient = null;
     this.autostart = true;
-    this.follow = true; // Default to true, user can disable temporarily
+    this.follow = true;
     this.closing = false;
     this.animateOpen = false;
     this.opening = false;
+    this.reconnect = false;
+    this._reconnectDelay = 0;
+    this._reconnectTimer = null;
+    this._reconnectStopped = false;
   }
 
   connectedCallback() {
     super.connectedCallback();
+    this._reconnectStopped = false;
     this.setupSocketConnection();
     this._boundTransitionEnd = this._onTransitionEnd.bind(this);
     this.addEventListener('transitionend', this._boundTransitionEnd);
@@ -53,6 +59,8 @@ class LogViewer extends LitElement {
       cancelAnimationFrame(this._openRaf);
       this._openRaf = null;
     }
+    this._reconnectStopped = true;
+    clearTimeout(this._reconnectTimer);
     this.removeEventListener('transitionend', this._boundTransitionEnd);
     super.disconnectedCallback();
     if (this.wsClient) {
@@ -162,6 +170,7 @@ class LogViewer extends LitElement {
     // Update component state based on WebSocket events
     this.wsClient.onOpen = (event) => {
       this.isConnected = true;
+      this._reconnectDelay = 0;
       this.requestUpdate();
     };
 
@@ -202,12 +211,31 @@ class LogViewer extends LitElement {
 
     this.wsClient.onClose = (event) => {
       this.isConnected = false;
+      this.wsClient = null;
       this.requestUpdate();
+      this._scheduleReconnect();
     };
 
     if (this.autostart) {
       this.wsClient.connect();
     }
+  }
+
+  _scheduleReconnect() {
+    if (!this.reconnect || this._reconnectStopped) return;
+    if (!this.jobId && !this.pupId) return;
+
+    const BASE = 1000;
+    const MAX = 15000;
+    this._reconnectDelay = Math.min(
+      this._reconnectDelay ? this._reconnectDelay * 2 : BASE,
+      MAX,
+    );
+
+    this._reconnectTimer = setTimeout(() => {
+      if (this._reconnectStopped) return;
+      this.setupSocketConnection();
+    }, this._reconnectDelay);
   }
 
   handleDownloadClick(e) {

--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -17,8 +17,8 @@ class LogViewer extends LitElement {
       jobId: { type: String },
       closing: { type: Boolean, reflect: true },
       animateOpen: { type: Boolean },
-      opening: { type: Boolean, reflect: true },
-      reconnect: { type: Boolean },
+      animatingOpen: { type: Boolean, reflect: true },
+      autoReconnect: { type: Boolean },
       connecting: { type: Boolean },
       isDownloading: { type: Boolean },
     };
@@ -33,11 +33,11 @@ class LogViewer extends LitElement {
     this.isLoadingHistory = false;
     this.wsClient = null;
     this.autostart = true;
-    this.follow = true;
+    this.follow = true; // Default to true, user can disable temporarily
     this.closing = false;
     this.animateOpen = false;
-    this.opening = false;
-    this.reconnect = false;
+    this.animatingOpen = false;
+    this.autoReconnect = false;
     this.connecting = false;
     this.isDownloading = false;
     this._streamToken = 0;
@@ -53,10 +53,10 @@ class LogViewer extends LitElement {
     this._boundTransitionEnd = this._onTransitionEnd.bind(this);
     this.addEventListener('transitionend', this._boundTransitionEnd);
     if (this.animateOpen && (this.jobId || this.pupId)) {
-      this.opening = true;
+      this.animatingOpen = true;
       this._openRaf = requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          this.opening = false;
+          this.animatingOpen = false;
           this._openRaf = null;
         });
       });
@@ -330,7 +330,7 @@ class LogViewer extends LitElement {
   }
 
   _scheduleReconnect() {
-    if (!this.reconnect || this._reconnectStopped) return;
+    if (!this.autoReconnect || this._reconnectStopped) return;
     if (!this.jobId && !this.pupId) return;
 
     const BASE = 1000;
@@ -429,6 +429,14 @@ class LogViewer extends LitElement {
   }
 
   render() {
+    const emptyStateMessage = this.connecting
+      ? 'Connecting to log stream...'
+      : this.isLoadingHistory
+        ? 'Loading recent logs...'
+        : this.isConnected
+          ? 'Connected. Waiting for log output...'
+          : 'Disconnected. Logs not available.';
+
     return html`
       <div>
         <div id="LogHUD">
@@ -448,13 +456,7 @@ class LogViewer extends LitElement {
             </ul>
           ` : html`
             <div class="no-logs-message">
-              ${this.connecting
-                ? 'Waiting for logs...'
-                : this.isLoadingHistory
-                ? 'Loading logs...'
-                : this.isConnected
-                  ? 'Waiting for logs...'
-                  : 'Logs not available'}
+              ${emptyStateMessage}
             </div>
           `}
         </div>
@@ -498,7 +500,7 @@ class LogViewer extends LitElement {
         max-height: 0;
       }
 
-      :host([opening]) {
+      :host([animatingOpen]) {
         max-height: 0;
       }
       div#LogHUD {

--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -16,6 +16,7 @@ class LogViewer extends LitElement {
       animateOpen: { type: Boolean },
       opening: { type: Boolean, reflect: true },
       reconnect: { type: Boolean },
+      connecting: { type: Boolean },
     };
   }
 
@@ -32,6 +33,7 @@ class LogViewer extends LitElement {
     this.animateOpen = false;
     this.opening = false;
     this.reconnect = false;
+    this.connecting = false;
     this._reconnectDelay = 0;
     this._reconnectTimer = null;
     this._reconnectStopped = false;
@@ -138,6 +140,10 @@ class LogViewer extends LitElement {
   }
 
   handleToggleConnection() {
+    if (!this.wsClient) {
+      return;
+    }
+
     if (this.wsClient.isConnected) {
       this.wsClient.disconnect();
     } else {
@@ -278,9 +284,11 @@ class LogViewer extends LitElement {
       <div>
         <div id="LogHUD">
           <div class="status">
-            ${this.isConnected
-              ? html`<sl-tag size="small" pill @click=${this.handleToggleConnection} variant="success">Connected</sl-tag>`
-              : html`<sl-tag size="small" pill @click=${this.handleToggleConnection} variant="neutral">Disconnected</sl-tag>`
+            ${this.connecting
+              ? html`<sl-tag size="small" pill variant="primary">Connecting</sl-tag>`
+              : this.isConnected
+                ? html`<sl-tag size="small" pill @click=${this.handleToggleConnection} variant="success">Connected</sl-tag>`
+                : html`<sl-tag size="small" pill @click=${this.handleToggleConnection} variant="neutral">Disconnected</sl-tag>`
             }
           </div>
         </div>
@@ -291,7 +299,11 @@ class LogViewer extends LitElement {
             </ul>
           ` : html`
             <div class="no-logs-message">
-              ${this.isConnected ? 'Waiting for logs...' : 'Logs not available'}
+              ${this.connecting
+                ? 'Waiting for logs...'
+                : this.isConnected
+                  ? 'Waiting for logs...'
+                  : 'Logs not available'}
             </div>
           `}
         </div>

--- a/src/controllers/sockets/job-channel.js
+++ b/src/controllers/sockets/job-channel.js
@@ -19,6 +19,20 @@ class JobWebSocketService {
     const { useMocks, wsApiBaseUrl } = store.networkContext;
     this.isMockMode = useMocks;
 
+    if (this.ws) {
+      if (this.isMockMode && this.ws.connected) {
+        return;
+      }
+
+      if (
+        !this.isMockMode &&
+        (this.ws.readyState === WebSocket.OPEN ||
+          this.ws.readyState === WebSocket.CONNECTING)
+      ) {
+        return;
+      }
+    }
+
     if (this.isMockMode) {
       this.ws = createMockJobWebSocket();
       this.setupMockHandlers();


### PR DESCRIPTION
### Summary
Adds a new page to the setup workflow, after the 'connect' step, which displays logs for the subsequent Nix rebuild. 

### Description
Previously, when a user pressed the 'Much Connect' button after selecting a network a Nix rebuild would occur. This could take up to 10 minutes however no progress was shown to the user. It was unclear if an error occurred and refreshing the page would navigate to the first setup step despite a rebuild processing in the background.

This PR adds the following:
- **A new 'Setting up' page** - shows logs from the backend while the rebuild is running
  - On success, the existing 'Congratulations' screen is shown
  - On failure, an error message is shown alongside a back button, allowing the user to return to previous setup steps and adjust as needed
- **Refresh resilience** - Reloading on any setup step will no longer take the user back to the first step, instead they stay exactly where they were up to.
- **Back navigation** - Users can navigate backwards through the setup steps to adjust previous pages

### Screen Recordings
**Setup logs page**
![setup logs](https://github.com/user-attachments/assets/6db3bb48-98ab-41a5-a8f0-a2d8d5bb68df)

**Example error**
![setup logs - failure to add pup source](https://github.com/user-attachments/assets/cc5bcd60-3d3e-41fa-876f-b06916c7c88a)

### Backend PR
https://github.com/Dogebox-WG/dogeboxd/pull/202