### PR TITLE
'Time ago' tooltip

### DIFF
--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
-import { timeAgo } from '/utils/time-format.js';
+import { timeAgo, formatDateTime } from '/utils/time-format.js';
 import { store } from '/state/store.js';
 import '/components/views/x-log-viewer/index.js';
 
@@ -271,6 +271,11 @@ class JobProgress extends LitElement {
       overflow: hidden;
       text-overflow: ellipsis;
     }
+
+    .timing-tooltip {
+      --show-delay: 0ms;
+      --hide-delay: 0ms;
+    }
     
   `;
   
@@ -339,13 +344,17 @@ class JobProgress extends LitElement {
             ${started ? html`
               <div class="timing-item">
                 <div class="timing-label">Started</div>
-                <div class="timing-value">${timeAgo(started)}</div>
+                <sl-tooltip class="timing-tooltip" content="${formatDateTime(started)}">
+                  <div class="timing-value">${timeAgo(started)}</div>
+                </sl-tooltip>
               </div>
             ` : ''}
             ${finished ? html`
               <div class="timing-item">
                 <div class="timing-label">Finished</div>
-                <div class="timing-value">${timeAgo(finished)}</div>
+                <sl-tooltip class="timing-tooltip" content="${formatDateTime(finished)}">
+                  <div class="timing-value">${timeAgo(finished)}</div>
+                </sl-tooltip>
               </div>
             ` : ''}
           </div>

--- a/src/utils/time-format.js
+++ b/src/utils/time-format.js
@@ -33,12 +33,30 @@ export function timeAgo(timestamp) {
     return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
   }
   
-  // Less than 7 days
-  if (days < 7) {
-    return `${days} ${days === 1 ? 'day' : 'days'} ago`;
-  }
-  
-  // More than 7 days
-  return 'a while ago';
+  return `${days} ${days === 1 ? 'day' : 'days'} ago`;
+}
+
+/**
+ * Formats a timestamp in the browser's local timezone.
+ * @param {string|number|Date} timestamp - The timestamp to format
+ * @returns {string} Date/time like "09-Apr-2026 14:30"
+ */
+export function formatDateTime(timestamp) {
+  if (!timestamp) return '';
+
+  const d = new Date(timestamp);
+
+  if (Number.isNaN(d.getTime())) return '';
+
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = d.toLocaleDateString('en-GB', { month: 'short' });
+  const year = d.getFullYear();
+  const time = d.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  });
+
+  return `${day}-${month}-${year} ${time}`;
 }
 

--- a/src/utils/time-format.js
+++ b/src/utils/time-format.js
@@ -42,21 +42,19 @@ export function timeAgo(timestamp) {
  * @returns {string} Date/time like "09-Apr-2026 14:30"
  */
 export function formatDateTime(timestamp) {
-  if (!timestamp) return '';
+  if (timestamp == null || timestamp === '') return '';
 
   const d = new Date(timestamp);
 
   if (Number.isNaN(d.getTime())) return '';
 
-  const day = String(d.getDate()).padStart(2, '0');
-  const month = d.toLocaleDateString('en-GB', { month: 'short' });
-  const year = d.getFullYear();
-  const time = d.toLocaleTimeString('en-GB', {
+  return d.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
     hour12: false
   });
-
-  return `${day}-${month}-${year} ${time}`;
 }
 


### PR DESCRIPTION
<img width="1395" height="736" alt="Screenshot 2026-04-13 at 12 03 46 pm" src="https://github.com/user-attachments/assets/8d29cfa4-b873-45f7-901e-73314d5f3574" />

- Added tooltip showing time stamp to 'time ago' fields on System Activity page
- Updated `timeAgo` function to no longer show 'a while ago'. It stays with X day/days indefinitely