### PR TITLE
Orphaned Job Detection - frontend

### DIFF
--- a/src/api/jobs/jobs.js
+++ b/src/api/jobs/jobs.js
@@ -33,14 +33,6 @@ export async function deleteJob(jobId) {
   )();
 }
 
-// POST retry specific job
-export async function retryJob(jobId) {
-  return useMock(
-    () => mockJobApi.retryJob(jobId),
-    () => client.post(`/jobs/${jobId}/retry`, {})
-  )();
-}
-
 // POST create orphaned job candidate
 export async function createOrphanedJobCandidate() {
   return useMock(

--- a/src/api/jobs/jobs.js
+++ b/src/api/jobs/jobs.js
@@ -25,6 +25,30 @@ export async function getJob(jobId) {
   )();
 }
 
+// DELETE specific job
+export async function deleteJob(jobId) {
+  return useMock(
+    () => mockJobApi.deleteJob(jobId),
+    () => client.delete(`/jobs/${jobId}`)
+  )();
+}
+
+// POST retry specific job
+export async function retryJob(jobId) {
+  return useMock(
+    () => mockJobApi.retryJob(jobId),
+    () => client.post(`/jobs/${jobId}/retry`, {})
+  )();
+}
+
+// POST create orphaned job candidate
+export async function createOrphanedJobCandidate() {
+  return useMock(
+    () => mockJobApi.createOrphanedJobCandidate(),
+    () => client.post('/jobs/dev/create-orphan-candidate', {})
+  )();
+}
+
 
 // Clear completed jobs
 export async function clearCompletedJobs(olderThanDays = 0) {

--- a/src/api/jobs/jobs.js
+++ b/src/api/jobs/jobs.js
@@ -6,46 +6,51 @@ const client = new ApiClient(store.networkContext.apiBaseUrl);
 
 // Helper to choose mock or real
 function useMock(mockFn, realFn) {
-  return store.networkContext.useMocks ? mockFn : realFn;
+  const useMocks = store.networkContext.useMocks;
+  return useMocks ? mockFn : realFn;
 }
 
 // GET all jobs
 export async function getAllJobs() {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.getAllJobs(),
     () => client.get('/jobs')
   )();
+  return result;
 }
 
 // GET specific job
 export async function getJob(jobId) {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.getJob(jobId),
     () => client.get(`/jobs/${jobId}`)
   )();
+  return result;
 }
 
 // DELETE specific job
 export async function deleteJob(jobId) {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.deleteJob(jobId),
     () => client.delete(`/jobs/${jobId}`)
   )();
+  return result;
 }
 
 // POST create orphaned job candidate
 export async function createOrphanedJobCandidate() {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.createOrphanedJobCandidate(),
     () => client.post('/jobs/dev/create-orphan-candidate', {})
   )();
+  return result;
 }
-
 
 // Clear completed jobs
 export async function clearCompletedJobs(olderThanDays = 0) {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.clearCompletedJobs(olderThanDays),
     () => client.post('/jobs/clear-completed', { olderThanDays })
   )();
+  return result;
 }

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -1,4 +1,5 @@
 import { store } from '/state/store.js';
+import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 
 /**
  * Lightweight mock for job system
@@ -229,7 +230,7 @@ export const mockJobApi = {
   clearCompletedJobs: (olderThanDays) => {
     const cutoff = new Date(Date.now() - (olderThanDays * 24 * 60 * 60 * 1000));
     mockJobs = mockJobs.filter(j => {
-      const isCompleted = ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status);
+      const isCompleted = isTerminalJobStatus(j.status);
       if (!isCompleted) return true;
       
       const jobDate = new Date(j.finished || j.started);

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -1,5 +1,5 @@
 import { store } from '/state/store.js';
-import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isFinishedJobStatus } from '/controllers/jobs/status.js';
 
 /**
  * Lightweight mock for job system
@@ -197,8 +197,8 @@ export const mockJobApi = {
   clearCompletedJobs: (olderThanDays) => {
     const cutoff = new Date(Date.now() - (olderThanDays * 24 * 60 * 60 * 1000));
     mockJobs = mockJobs.filter(j => {
-      const isCompleted = isTerminalJobStatus(j.status);
-      if (!isCompleted) return true;
+      const isFinished = isFinishedJobStatus(j.status);
+      if (!isFinished) return true;
       
       const jobDate = new Date(j.finished || j.started);
       return jobDate >= cutoff;

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -188,40 +188,6 @@ export const mockJobApi = {
     return Promise.resolve({ success: true, deleted: id });
   },
 
-  retryJob: (id) => {
-    const originalJob = mockJobs.find(j => String(j.id) === String(id));
-    mockJobs = mockJobs.filter(j => String(j.id) !== String(id));
-
-    const newJob = {
-      id: mockJobId++,
-      started: new Date().toISOString(),
-      finished: null,
-      displayName: originalJob?.displayName || 'Retried Job',
-      progress: 0,
-      status: 'queued',
-      summaryMessage: 'Job queued',
-      errorMessage: null,
-    };
-
-    mockJobs.unshift(newJob);
-
-    if (mockJobWS) {
-      mockJobWS.send({
-        type: 'job:deleted',
-        update: { id }
-      });
-      mockJobWS.send({
-        type: 'job:created',
-        update: newJob
-      });
-      setTimeout(() => {
-        mockJobWS.simulateProgress(newJob.id);
-      }, 250);
-    }
-
-    return Promise.resolve({ success: true, id: newJob.id });
-  },
-
   createOrphanedJobCandidate: () => {
     return Promise.reject(new Error('Create orphaned job requires the real backend with Network Mocks disabled.'));
   },

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -45,8 +45,8 @@ class MockJobWebSocket {
       this.trigger('open');
       // Send initial jobs
       this.send({
-        type: 'initial',
-        data: mockJobs
+        type: 'bootstrap',
+        update: { jobs: mockJobs }
       });
     }, 100);
 
@@ -92,7 +92,7 @@ class MockJobWebSocket {
     
     this.send({
       type: 'job:created',
-      data: job
+        update: job
     });
 
     // Simulate progress after 2 seconds
@@ -104,7 +104,7 @@ class MockJobWebSocket {
   // Helper: Simulate progress updates
   simulateProgress(jobId) {
     const job = mockJobs.find(a => a.id === jobId);
-    if (!activity) return;
+    if (!job) return;
     
     if (job.status !== 'in_progress' && job.status !== 'queued') {
       return;
@@ -116,13 +116,13 @@ class MockJobWebSocket {
       job.summaryMessage = 'Starting...';
       this.send({
         type: 'job:updated',
-        data: { ...job }
+        update: { ...job }
       });
     }
 
     // Progress update loop
     const interval = setInterval(() => {
-      if (!activity || job.status !== 'in_progress') {
+      if (!job || job.status !== 'in_progress') {
         clearInterval(interval);
         return;
       }
@@ -143,7 +143,7 @@ class MockJobWebSocket {
         
         this.send({
           type: `job:${job.status}`,
-          data: { ...job }
+          update: { ...job }
         });
         
         clearInterval(interval);
@@ -151,7 +151,7 @@ class MockJobWebSocket {
         job.summaryMessage = `Processing... ${job.progress}%`;
         this.send({
           type: 'job:updated',
-          data: { ...job }
+          update: { ...job }
         });
       }
     }, 1500);
@@ -175,11 +175,61 @@ export const mockJobApi = {
     });
   },
 
+  deleteJob: (id) => {
+    const deletedJob = mockJobs.find(j => String(j.id) === String(id));
+    mockJobs = mockJobs.filter(j => String(j.id) !== String(id));
+    if (mockJobWS) {
+      mockJobWS.send({
+        type: 'job:deleted',
+        update: { id: deletedJob?.id ?? id }
+      });
+    }
+    return Promise.resolve({ success: true, deleted: id });
+  },
+
+  retryJob: (id) => {
+    const originalJob = mockJobs.find(j => String(j.id) === String(id));
+    mockJobs = mockJobs.filter(j => String(j.id) !== String(id));
+
+    const newJob = {
+      id: mockJobId++,
+      started: new Date().toISOString(),
+      finished: null,
+      displayName: originalJob?.displayName || 'Retried Job',
+      progress: 0,
+      status: 'queued',
+      summaryMessage: 'Job queued',
+      errorMessage: null,
+    };
+
+    mockJobs.unshift(newJob);
+
+    if (mockJobWS) {
+      mockJobWS.send({
+        type: 'job:deleted',
+        update: { id }
+      });
+      mockJobWS.send({
+        type: 'job:created',
+        update: newJob
+      });
+      setTimeout(() => {
+        mockJobWS.simulateProgress(newJob.id);
+      }, 250);
+    }
+
+    return Promise.resolve({ success: true, id: newJob.id });
+  },
+
+  createOrphanedJobCandidate: () => {
+    return Promise.reject(new Error('Create orphaned job requires the real backend with Network Mocks disabled.'));
+  },
+
 
   clearCompletedJobs: (olderThanDays) => {
     const cutoff = new Date(Date.now() - (olderThanDays * 24 * 60 * 60 * 1000));
     mockJobs = mockJobs.filter(j => {
-      const isCompleted = ['completed', 'failed'].includes(j.status);
+      const isCompleted = ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status);
       if (!isCompleted) return true;
       
       const jobDate = new Date(j.finished || j.started);

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -1,5 +1,5 @@
 import { store } from '/state/store.js';
-import { isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
 
 /**
  * Lightweight mock for job system
@@ -107,7 +107,8 @@ class MockJobWebSocket {
     const job = mockJobs.find(a => a.id === jobId);
     if (!job) return;
     
-    if (job.status !== 'in_progress' && job.status !== 'queued') {
+    const isActive = isActiveJobStatus(job.status);
+    if (!isActive) {
       return;
     }
 

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { timeAgo, formatDateTime } from '/utils/time-format.js';
-import { isDeletableJobStatus, isRetryableJobStatus } from '/controllers/jobs/status.js';
+import { isDeletableJobStatus } from '/controllers/jobs/status.js';
 import { store } from '/state/store.js';
 import '/components/views/x-log-viewer/index.js';
 
@@ -334,22 +334,9 @@ class JobProgress extends LitElement {
     return isDeletableJobStatus(status);
   }
 
-  canRetry(status) {
-    return isRetryableJobStatus(status);
-  }
-
   handleDeleteClick(e) {
     e.stopPropagation();
     this.dispatchEvent(new CustomEvent('job-delete', {
-      detail: { job: this.job },
-      bubbles: true,
-      composed: true
-    }));
-  }
-
-  handleRetryClick(e) {
-    e.stopPropagation();
-    this.dispatchEvent(new CustomEvent('job-retry', {
       detail: { job: this.job },
       bubbles: true,
       composed: true
@@ -383,22 +370,13 @@ class JobProgress extends LitElement {
             <div class="job-percentage">${isIndeterminate ? '...' : `${progress}%`}</div>
           </div>
 
-          ${(this.canRetry(status) || this.canDelete(status)) ? html`
+          ${this.canDelete(status) ? html`
             <div class="job-actions">
-              ${this.canRetry(status) ? html`
-                <sl-icon-button
-                  name="arrow-repeat"
-                  label="Retry job"
-                  @click=${this.handleRetryClick}
-                ></sl-icon-button>
-              ` : ''}
-              ${this.canDelete(status) ? html`
-                <sl-icon-button
-                  name="trash"
-                  label="Delete job"
-                  @click=${this.handleDeleteClick}
-                ></sl-icon-button>
-              ` : ''}
+              <sl-icon-button
+                name="trash"
+                label="Delete job"
+                @click=${this.handleDeleteClick}
+              ></sl-icon-button>
             </div>
           ` : ''}
           

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { timeAgo, formatDateTime } from '/utils/time-format.js';
+import { isDeletableJobStatus, isRetryableJobStatus } from '/controllers/jobs/status.js';
 import { store } from '/state/store.js';
 import '/components/views/x-log-viewer/index.js';
 
@@ -330,11 +331,11 @@ class JobProgress extends LitElement {
   }
 
   canDelete(status) {
-    return status === 'queued';
+    return isDeletableJobStatus(status);
   }
 
   canRetry(status) {
-    return ['orphaned', 'failed', 'cancelled'].includes(status);
+    return isRetryableJobStatus(status);
   }
 
   handleDeleteClick(e) {

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -330,10 +330,6 @@ class JobProgress extends LitElement {
     return icons[status] || 'question-circle';
   }
 
-  canDelete(status) {
-    return isDeletableJobStatus(status);
-  }
-
   handleDeleteClick(e) {
     e.stopPropagation();
     this.dispatchEvent(new CustomEvent('job-delete', {
@@ -370,7 +366,7 @@ class JobProgress extends LitElement {
             <div class="job-percentage">${isIndeterminate ? '...' : `${progress}%`}</div>
           </div>
 
-          ${this.canDelete(status) ? html`
+          ${isDeletableJobStatus(status) ? html`
             <div class="job-actions">
               <sl-icon-button
                 name="trash"

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -76,6 +76,10 @@ class JobProgress extends LitElement {
     .job-icon.failed {
       color: #ff6b6b;
     }
+
+    .job-icon.orphaned {
+      color: #f0ad4e;
+    }
     
     .job-icon.queued {
       color: #888;
@@ -147,6 +151,10 @@ class JobProgress extends LitElement {
     .progress-bar.failed {
       background: linear-gradient(90deg, #ff6b6b, #ff8787);
     }
+
+    .progress-bar.orphaned {
+      background: linear-gradient(90deg, #f0ad4e, #f7c46c);
+    }
     
     .progress-bar.queued {
       background: #555;
@@ -193,6 +201,13 @@ class JobProgress extends LitElement {
       color: #888;
       flex: 0 0 200px;
       min-width: 200px;
+    }
+
+    .job-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.25em;
+      flex: 0 0 auto;
     }
     
     .timing-item {
@@ -302,10 +317,37 @@ class JobProgress extends LitElement {
       in_progress: 'arrow-repeat',
       completed: 'check-circle-fill',
       failed: 'exclamation-triangle-fill',
+      orphaned: 'exclamation-octagon',
       queued: 'clock',
       cancelled: 'x-circle'
     };
     return icons[status] || 'question-circle';
+  }
+
+  canDelete(status) {
+    return status === 'queued';
+  }
+
+  canRetry(status) {
+    return ['orphaned', 'failed', 'cancelled'].includes(status);
+  }
+
+  handleDeleteClick(e) {
+    e.stopPropagation();
+    this.dispatchEvent(new CustomEvent('job-delete', {
+      detail: { job: this.job },
+      bubbles: true,
+      composed: true
+    }));
+  }
+
+  handleRetryClick(e) {
+    e.stopPropagation();
+    this.dispatchEvent(new CustomEvent('job-retry', {
+      detail: { job: this.job },
+      bubbles: true,
+      composed: true
+    }));
   }
   
   render() {
@@ -334,6 +376,25 @@ class JobProgress extends LitElement {
             
             <div class="job-percentage">${isIndeterminate ? '...' : `${progress}%`}</div>
           </div>
+
+          ${(this.canRetry(status) || this.canDelete(status)) ? html`
+            <div class="job-actions">
+              ${this.canRetry(status) ? html`
+                <sl-icon-button
+                  name="arrow-repeat"
+                  label="Retry job"
+                  @click=${this.handleRetryClick}
+                ></sl-icon-button>
+              ` : ''}
+              ${this.canDelete(status) ? html`
+                <sl-icon-button
+                  name="trash"
+                  label="Delete job"
+                  @click=${this.handleDeleteClick}
+                ></sl-icon-button>
+              ` : ''}
+            </div>
+          ` : ''}
           
           <div class="timing-info">
             ${started ? html`

--- a/src/components/common/job-progress/job-channel.test.js
+++ b/src/components/common/job-progress/job-channel.test.js
@@ -1,0 +1,50 @@
+import { expect } from "../../../../dev/node_modules/@open-wc/testing";
+
+import { store } from "/state/store.js";
+import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+
+describe("jobWebSocket", () => {
+  beforeEach(() => {
+    store.updateState({
+      jobsContext: {
+        jobs: [
+          {
+            id: "job-1",
+            displayName: "Tracked Job",
+            status: "in_progress",
+            progress: 30,
+            summaryMessage: "Running",
+            errorMessage: null,
+            started: new Date().toISOString(),
+            finished: null,
+          },
+        ],
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  it("updates orphaned jobs and removes deleted jobs", () => {
+    jobWebSocket.handleMessage({
+      type: "job:orphaned",
+      update: {
+        id: "job-1",
+        status: "orphaned",
+        progress: 30,
+        summaryMessage: "Job marked as orphaned",
+        errorMessage: "Job is no longer being processed",
+      },
+    });
+
+    expect(store.jobsContext.jobs[0].status).to.equal("orphaned");
+    expect(store.jobsContext.jobs[0].errorMessage).to.equal("Job is no longer being processed");
+
+    jobWebSocket.handleMessage({
+      type: "job:deleted",
+      update: { id: "job-1" },
+    });
+
+    expect(store.jobsContext.jobs).to.deep.equal([]);
+  });
+});

--- a/src/components/common/job-progress/job-channel.test.js
+++ b/src/components/common/job-progress/job-channel.test.js
@@ -18,6 +18,16 @@ describe("jobWebSocket", () => {
             started: new Date().toISOString(),
             finished: null,
           },
+          {
+            id: "job-2",
+            displayName: "Queued Job",
+            status: "queued",
+            progress: 0,
+            summaryMessage: "Queued",
+            errorMessage: null,
+            started: new Date().toISOString(),
+            finished: null,
+          },
         ],
         loading: false,
         error: null,
@@ -25,26 +35,45 @@ describe("jobWebSocket", () => {
     });
   });
 
-  it("updates orphaned jobs and removes deleted jobs", () => {
+  it("merges orphaned job updates without disturbing other jobs", () => {
     jobWebSocket.handleMessage({
       type: "job:orphaned",
       update: {
         id: "job-1",
         status: "orphaned",
-        progress: 30,
-        summaryMessage: "Job marked as orphaned",
+        progress: 42,
+        summaryMessage: "Marked as orphaned",
         errorMessage: "Job is no longer being processed",
       },
     });
 
-    expect(store.jobsContext.jobs[0].status).to.equal("orphaned");
-    expect(store.jobsContext.jobs[0].errorMessage).to.equal("Job is no longer being processed");
+    expect(store.jobsContext.jobs[0]).to.include({
+      id: "job-1",
+      displayName: "Tracked Job",
+      status: "orphaned",
+      progress: 42,
+      summaryMessage: "Marked as orphaned",
+      errorMessage: "Job is no longer being processed",
+    });
+    expect(store.jobsContext.jobs[1]).to.include({
+      id: "job-2",
+      displayName: "Queued Job",
+      status: "queued",
+      progress: 0,
+    });
+  });
 
+  it("removes only the deleted job", () => {
     jobWebSocket.handleMessage({
       type: "job:deleted",
       update: { id: "job-1" },
     });
 
-    expect(store.jobsContext.jobs).to.deep.equal([]);
+    expect(store.jobsContext.jobs).to.have.length(1);
+    expect(store.jobsContext.jobs[0]).to.include({
+      id: "job-2",
+      displayName: "Queued Job",
+      status: "queued",
+    });
   });
 });

--- a/src/components/common/job-progress/job-progress.test.js
+++ b/src/components/common/job-progress/job-progress.test.js
@@ -3,7 +3,7 @@ import { html, fixture, expect } from "../../../../dev/node_modules/@open-wc/tes
 import "./index.js";
 
 describe("JobProgress", () => {
-  it("shows delete but not retry for queued jobs", async () => {
+  it("shows delete for queued jobs", async () => {
     const job = {
       id: "job-1",
       displayName: "Queued Job",
@@ -17,10 +17,8 @@ describe("JobProgress", () => {
 
     const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
 
-    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
     const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
 
-    expect(retryButton).to.not.exist;
     expect(deleteButton).to.exist;
 
     const deleteEventPromise = new Promise((resolve) => {
@@ -31,29 +29,18 @@ describe("JobProgress", () => {
     expect(deleteEvent.detail.job).to.equal(job);
   });
 
-  it("shows retry but not delete for failed jobs", async () => {
-    const job = {
-      id: "job-2",
-      displayName: "Failed Job",
-      status: "failed",
-      progress: 80,
-      summaryMessage: "Failed",
-      errorMessage: "Boom",
-      started: new Date().toISOString(),
-      finished: new Date().toISOString(),
-    };
-
-    const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
-
-    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
-    const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
-
-    expect(retryButton).to.exist;
-    expect(deleteButton).to.not.exist;
-  });
-
-  it("shows retry but not delete for orphaned and cancelled jobs", async () => {
+  it("does not show actions for non-queued jobs", async () => {
     const jobs = [
+      {
+        id: "job-2",
+        displayName: "Failed Job",
+        status: "failed",
+        progress: 80,
+        summaryMessage: "Failed",
+        errorMessage: "Boom",
+        started: new Date().toISOString(),
+        finished: new Date().toISOString(),
+      },
       {
         id: "job-3",
         displayName: "Orphaned Job",
@@ -79,10 +66,8 @@ describe("JobProgress", () => {
     for (const job of jobs) {
       const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
 
-      const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
       const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
 
-      expect(retryButton).to.exist;
       expect(deleteButton).to.not.exist;
     }
   });

--- a/src/components/common/job-progress/job-progress.test.js
+++ b/src/components/common/job-progress/job-progress.test.js
@@ -1,0 +1,89 @@
+import { html, fixture, expect } from "../../../../dev/node_modules/@open-wc/testing";
+
+import "./index.js";
+
+describe("JobProgress", () => {
+  it("shows delete but not retry for queued jobs", async () => {
+    const job = {
+      id: "job-1",
+      displayName: "Queued Job",
+      status: "queued",
+      progress: 0,
+      summaryMessage: "Queued",
+      errorMessage: null,
+      started: new Date().toISOString(),
+      finished: null,
+    };
+
+    const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
+
+    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
+    const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
+
+    expect(retryButton).to.not.exist;
+    expect(deleteButton).to.exist;
+
+    const deleteEventPromise = new Promise((resolve) => {
+      el.addEventListener("job-delete", resolve, { once: true });
+    });
+    deleteButton.click();
+    const deleteEvent = await deleteEventPromise;
+    expect(deleteEvent.detail.job).to.equal(job);
+  });
+
+  it("shows retry but not delete for failed jobs", async () => {
+    const job = {
+      id: "job-2",
+      displayName: "Failed Job",
+      status: "failed",
+      progress: 80,
+      summaryMessage: "Failed",
+      errorMessage: "Boom",
+      started: new Date().toISOString(),
+      finished: new Date().toISOString(),
+    };
+
+    const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
+
+    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
+    const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
+
+    expect(retryButton).to.exist;
+    expect(deleteButton).to.not.exist;
+  });
+
+  it("shows retry but not delete for orphaned and cancelled jobs", async () => {
+    const jobs = [
+      {
+        id: "job-3",
+        displayName: "Orphaned Job",
+        status: "orphaned",
+        progress: 40,
+        summaryMessage: "Job marked as orphaned",
+        errorMessage: "Job is no longer being processed",
+        started: new Date().toISOString(),
+        finished: new Date().toISOString(),
+      },
+      {
+        id: "job-4",
+        displayName: "Cancelled Job",
+        status: "cancelled",
+        progress: 80,
+        summaryMessage: "Cancelled by user",
+        errorMessage: null,
+        started: new Date().toISOString(),
+        finished: new Date().toISOString(),
+      },
+    ];
+
+    for (const job of jobs) {
+      const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
+
+      const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
+      const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
+
+      expect(retryButton).to.exist;
+      expect(deleteButton).to.not.exist;
+    }
+  });
+});

--- a/src/components/common/job-progress/job-progress.test.js
+++ b/src/components/common/job-progress/job-progress.test.js
@@ -29,7 +29,7 @@ describe("JobProgress", () => {
     expect(deleteEvent.detail.job).to.equal(job);
   });
 
-  it("does not show actions for non-queued jobs", async () => {
+  it("does not show delete for non-queued jobs", async () => {
     const jobs = [
       {
         id: "job-2",

--- a/src/components/views/action-check-updates/index.js
+++ b/src/components/views/action-check-updates/index.js
@@ -151,7 +151,7 @@ export class CheckUpdatesView extends LitElement {
     const jobs = this.context?.store?.jobsContext?.jobs || [];
     const job = jobs.find(item => item.id === this._systemJobId);
     if (!job) return;
-    if (job.status === "failed" || job.status === "cancelled") {
+    if (job.status === "failed" || job.status === "cancelled" || job.status === "orphaned") {
       this.markUpdateFailed();
     }
   }

--- a/src/components/views/action-check-updates/index.js
+++ b/src/components/views/action-check-updates/index.js
@@ -15,6 +15,7 @@ import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { getBootstrapV2 } from "/api/bootstrap/bootstrap.js";
 import { pkgController } from "/controllers/package/index.js";
+import { isFailureJobStatus } from "/controllers/jobs/status.js";
 import { getRouter } from "/router/index.js";
 
 const PAGE_ONE = "checking";
@@ -151,7 +152,7 @@ export class CheckUpdatesView extends LitElement {
     const jobs = this.context?.store?.jobsContext?.jobs || [];
     const job = jobs.find(item => item.id === this._systemJobId);
     if (!job) return;
-    if (job.status === "failed" || job.status === "cancelled" || job.status === "orphaned") {
+    if (isFailureJobStatus(job.status)) {
       this.markUpdateFailed();
     }
   }

--- a/src/components/views/action-setup-progress.test.js
+++ b/src/components/views/action-setup-progress.test.js
@@ -1,0 +1,57 @@
+import { html, fixture, expect } from "../../../dev/node_modules/@open-wc/testing";
+
+import { store } from "/state/store.js";
+import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+
+import "./action-setup-progress/index.js";
+
+describe("SetupProgress", () => {
+  beforeEach(() => {
+    store.updateState({
+      networkContext: {
+        ...store.networkContext,
+        useMocks: true,
+      },
+      jobsContext: {
+        jobs: [
+          {
+            id: "job-setup-1",
+            displayName: "Setup Dogebox",
+            status: "orphaned",
+            progress: 25,
+            summaryMessage: "Job marked as orphaned",
+            errorMessage: "Job is no longer being processed",
+            started: new Date().toISOString(),
+            finished: new Date().toISOString(),
+          },
+        ],
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  afterEach(() => {
+    jobWebSocket.disconnect();
+    store.updateState({
+      jobsContext: {
+        jobs: [],
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  it("treats orphaned jobs as failed setup outcomes", async () => {
+    const el = await fixture(
+      html`<x-action-setup-progress .jobId=${"job-setup-1"}></x-action-setup-progress>`
+    );
+
+    await el.updateComplete;
+
+    expect(el._failed).to.equal(true);
+    expect(el._completionHandled).to.equal(true);
+    expect(el.shadowRoot.querySelector(".error-bar")).to.exist;
+    expect(el.shadowRoot.textContent).to.contain("Job is no longer being processed");
+  });
+});

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -2,6 +2,7 @@ import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.m
 import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+import { isFailureJobStatus } from "/controllers/jobs/status.js";
 
 import "/components/views/x-log-viewer/index.js";
 
@@ -130,7 +131,7 @@ class SetupProgress extends LitElement {
       this.onSuccess && this.onSuccess();
     }
 
-    if (job.status === "failed" || job.status === "cancelled") {
+    if (isFailureJobStatus(job.status)) {
       this._completionHandled = true;
       this._failed = true;
       this._errorMessage =

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -1,5 +1,5 @@
 import { store } from "/state/store.js";
-import { isTerminalJobStatus } from "/controllers/jobs/status.js";
+import { isActiveJobStatus } from "/controllers/jobs/status.js";
 
 class JobsController {
   constructor() {
@@ -37,7 +37,7 @@ class JobsController {
     const status = (job?.status || "").toLowerCase();
 
     return (
-      name.includes(matchText.toLowerCase()) && !isTerminalJobStatus(status)
+      name.includes(matchText.toLowerCase()) && isActiveJobStatus(status)
     );
   }
 

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -33,7 +33,7 @@ class JobsController {
 
   isJobPending(job, matchText) {
     const name = (job?.displayName || "").toLowerCase();
-    const statusesToIgnore = ["completed", "failed", "cancelled"];
+    const statusesToIgnore = ["completed", "failed", "cancelled", "orphaned"];
     const status = (job?.status || "").toLowerCase();
 
     return (

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -1,4 +1,5 @@
 import { store } from "/state/store.js";
+import { isTerminalJobStatus } from "/controllers/jobs/status.js";
 
 class JobsController {
   constructor() {
@@ -33,11 +34,10 @@ class JobsController {
 
   isJobPending(job, matchText) {
     const name = (job?.displayName || "").toLowerCase();
-    const statusesToIgnore = ["completed", "failed", "cancelled", "orphaned"];
     const status = (job?.status || "").toLowerCase();
 
     return (
-      name.includes(matchText.toLowerCase()) && !statusesToIgnore.includes(status)
+      name.includes(matchText.toLowerCase()) && !isTerminalJobStatus(status)
     );
   }
 

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -5,16 +5,27 @@ export const TERMINAL_JOB_STATUSES = Object.freeze([
   "orphaned",
 ]);
 
+export const ACTIVE_JOB_STATUSES = Object.freeze([
+  "queued",
+  "in_progress",
+]);
+
 export const FAILURE_JOB_STATUSES = Object.freeze([
   "failed",
   "cancelled",
   "orphaned",
 ]);
 
-export const DELETABLE_JOB_STATUSES = Object.freeze(["queued"]);
+export const DELETABLE_JOB_STATUSES = Object.freeze([
+  "queued"
+]);
 
 export function isTerminalJobStatus(status) {
   return TERMINAL_JOB_STATUSES.includes(status);
+}
+
+export function isActiveJobStatus(status) {
+  return ACTIVE_JOB_STATUSES.includes(status);
 }
 
 export function isFailureJobStatus(status) {

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -11,12 +11,6 @@ export const FAILURE_JOB_STATUSES = Object.freeze([
   "orphaned",
 ]);
 
-export const RETRYABLE_JOB_STATUSES = Object.freeze([
-  "failed",
-  "cancelled",
-  "orphaned",
-]);
-
 export const DELETABLE_JOB_STATUSES = Object.freeze(["queued"]);
 
 export function isTerminalJobStatus(status) {
@@ -25,10 +19,6 @@ export function isTerminalJobStatus(status) {
 
 export function isFailureJobStatus(status) {
   return FAILURE_JOB_STATUSES.includes(status);
-}
-
-export function isRetryableJobStatus(status) {
-  return RETRYABLE_JOB_STATUSES.includes(status);
 }
 
 export function isDeletableJobStatus(status) {

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -1,0 +1,36 @@
+export const TERMINAL_JOB_STATUSES = Object.freeze([
+  "completed",
+  "failed",
+  "cancelled",
+  "orphaned",
+]);
+
+export const FAILURE_JOB_STATUSES = Object.freeze([
+  "failed",
+  "cancelled",
+  "orphaned",
+]);
+
+export const RETRYABLE_JOB_STATUSES = Object.freeze([
+  "failed",
+  "cancelled",
+  "orphaned",
+]);
+
+export const DELETABLE_JOB_STATUSES = Object.freeze(["queued"]);
+
+export function isTerminalJobStatus(status) {
+  return TERMINAL_JOB_STATUSES.includes(status);
+}
+
+export function isFailureJobStatus(status) {
+  return FAILURE_JOB_STATUSES.includes(status);
+}
+
+export function isRetryableJobStatus(status) {
+  return RETRYABLE_JOB_STATUSES.includes(status);
+}
+
+export function isDeletableJobStatus(status) {
+  return DELETABLE_JOB_STATUSES.includes(status);
+}

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -1,4 +1,4 @@
-export const TERMINAL_JOB_STATUSES = Object.freeze([
+export const FINISHED_JOB_STATUSES = Object.freeze([
   "completed",
   "failed",
   "cancelled",
@@ -20,8 +20,8 @@ export const DELETABLE_JOB_STATUSES = Object.freeze([
   "queued"
 ]);
 
-export function isTerminalJobStatus(status) {
-  return TERMINAL_JOB_STATUSES.includes(status);
+export function isFinishedJobStatus(status) {
+  return FINISHED_JOB_STATUSES.includes(status);
 }
 
 export function isActiveJobStatus(status) {

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -1,5 +1,6 @@
 import { postConfig } from "/api/config/config.js";
 import { pickAndPerformPupAction } from "/api/action/action.js";
+import { isTerminalJobStatus } from "/controllers/jobs/status.js";
 import { store } from "/state/store.js";
 
 class PkgController {
@@ -547,12 +548,8 @@ class PkgController {
   getJobsForPup(pupId) {
     // Get active jobs for this pup (enable/disable/install/etc)
     const jobs = store?.jobsContext?.jobs || [];
-    const activeJobs = jobs.filter(j => 
-      j.pupID === pupId && 
-      j.status !== 'completed' && 
-      j.status !== 'failed' && 
-      j.status !== 'cancelled' &&
-      j.status !== 'orphaned'
+    const activeJobs = jobs.filter(
+      (j) => j.pupID === pupId && !isTerminalJobStatus(j.status)
     );
     return activeJobs;
   }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -551,7 +551,8 @@ class PkgController {
       j.pupID === pupId && 
       j.status !== 'completed' && 
       j.status !== 'failed' && 
-      j.status !== 'cancelled'
+      j.status !== 'cancelled' &&
+      j.status !== 'orphaned'
     );
     return activeJobs;
   }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -1,6 +1,6 @@
 import { postConfig } from "/api/config/config.js";
 import { pickAndPerformPupAction } from "/api/action/action.js";
-import { isTerminalJobStatus } from "/controllers/jobs/status.js";
+import { isActiveJobStatus } from "/controllers/jobs/status.js";
 import { store } from "/state/store.js";
 
 class PkgController {
@@ -549,7 +549,7 @@ class PkgController {
     // Get active jobs for this pup (enable/disable/install/etc)
     const jobs = store?.jobsContext?.jobs || [];
     const activeJobs = jobs.filter(
-      (j) => j.pupID === pupId && !isTerminalJobStatus(j.status)
+      (j) => j.pupID === pupId && isActiveJobStatus(j.status)
     );
     return activeJobs;
   }
@@ -571,7 +571,7 @@ class PkgController {
 
     //Only show logs for jobs that are queued or in progress.
     const mostRecent = sorted[0];
-    const isActive = mostRecent.status === 'queued' || mostRecent.status === 'in_progress';
+    const isActive = isActiveJobStatus(mostRecent.status);
     if (isActive) {
       return mostRecent;
     }

--- a/src/controllers/sockets/job-channel.js
+++ b/src/controllers/sockets/job-channel.js
@@ -116,13 +116,11 @@ class JobWebSocketService {
         this.handleJobCreated(update);
         break;
       case 'job:updated':
-        this.handleJobUpdated(update);
-        break;
       case 'job:completed':
       case 'job:failed':
       case 'job:cancelled':
       case 'job:orphaned':
-        this.handleJobFinished(update);
+        this.handleJobUpdated(update);
         break;
       case 'job:deleted':
         this.handleJobDeleted(update);
@@ -156,15 +154,6 @@ class JobWebSocketService {
   }
 
   handleJobUpdated(job) {
-    const jobs = store.jobsContext.jobs.map(j =>
-      j.id === job.id ? { ...j, ...job } : j
-    );
-    store.updateState({
-      jobsContext: { jobs }
-    });
-  }
-
-  handleJobFinished(job) {
     const jobs = store.jobsContext.jobs.map(j =>
       j.id === job.id ? { ...j, ...job } : j
     );

--- a/src/controllers/sockets/job-channel.js
+++ b/src/controllers/sockets/job-channel.js
@@ -91,27 +91,27 @@ class JobWebSocketService {
 
   handleMessage(message) {
     const { type, update } = message;
-    
-    // Backend sends 'update' field, not 'data'
-    const data = update;
 
     switch (type) {
       case 'bootstrap':
-        // Initial connection sends bootstrap with all jobs
-        if (data && Array.isArray(data.jobs)) {
-          this.handleInitialJobs(data.jobs);
+        if (update && Array.isArray(update.jobs)) {
+          this.handleInitialJobs(update.jobs);
         }
         break;
       case 'job:created':
-        this.handleJobCreated(data);
+        this.handleJobCreated(update);
         break;
       case 'job:updated':
-        this.handleJobUpdated(data);
+        this.handleJobUpdated(update);
         break;
       case 'job:completed':
       case 'job:failed':
       case 'job:cancelled':
-        this.handleJobFinished(data);
+      case 'job:orphaned':
+        this.handleJobFinished(update);
+        break;
+      case 'job:deleted':
+        this.handleJobDeleted(update);
         break;
       default:
         // Ignore other message types (pup updates, stats, etc.)
@@ -154,6 +154,13 @@ class JobWebSocketService {
     const jobs = store.jobsContext.jobs.map(j =>
       j.id === job.id ? { ...j, ...job } : j
     );
+    store.updateState({
+      jobsContext: { jobs }
+    });
+  }
+
+  handleJobDeleted(job) {
+    const jobs = store.jobsContext.jobs.filter(j => j.id !== job?.id);
     store.updateState({
       jobsContext: { jobs }
     });

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
-import { clearCompletedJobs, deleteJob, retryJob } from '/api/jobs/jobs.js';
+import { clearCompletedJobs, deleteJob } from '/api/jobs/jobs.js';
 import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
@@ -287,23 +287,6 @@ class JobActivityPage extends LitElement {
       alert('Failed to delete job. Please try again.');
     }
   }
-
-  async handleRetryJob(e) {
-    const job = e.detail?.job;
-    if (!job?.id) return;
-
-    try {
-      await retryJob(job.id);
-      store.updateState({
-        jobsContext: {
-          jobs: store.jobsContext.jobs.filter(existingJob => existingJob.id !== job.id)
-        }
-      });
-    } catch (err) {
-      console.error('Failed to retry job:', err);
-      alert('Failed to retry job. Please try again.');
-    }
-  }
   
   filterJobs(jobs) {
     let filtered = jobs;
@@ -375,7 +358,6 @@ class JobActivityPage extends LitElement {
               .job=${job}
               ?initiallyExpanded=${job.id === targetJobId}
               @job-delete=${this.handleDeleteJob}
-              @job-retry=${this.handleRetryJob}
             ></job-progress>
           `)}
           

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
-import { clearCompletedJobs } from '/api/jobs/jobs.js';
+import { clearCompletedJobs, deleteJob, retryJob } from '/api/jobs/jobs.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -230,14 +230,14 @@ class JobActivityPage extends LitElement {
   
   async handleClearCompleted() {
     const { jobs } = store.jobsContext;
-    const completedCount = jobs.filter(j => ['completed', 'failed', 'cancelled'].includes(j.status)).length;
+    const completedCount = jobs.filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status)).length;
     
     if (completedCount === 0) {
-      alert('No completed jobs to clear.');
+      alert('No finished jobs to clear.');
       return;
     }
     
-    const confirmed = confirm(`Clear ${completedCount} completed/failed jobs? This action cannot be undone.`);
+    const confirmed = confirm(`Clear ${completedCount} finished jobs? This includes completed, failed, cancelled, and orphaned jobs.`);
     if (!confirmed) return;
     
     try {
@@ -245,7 +245,7 @@ class JobActivityPage extends LitElement {
       await clearCompletedJobs(0);
       
       // Update local state
-      const remainingJobs = jobs.filter(j => !['completed', 'failed', 'cancelled'].includes(j.status));
+      const remainingJobs = jobs.filter(j => !['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status));
       store.updateState({
         jobsContext: { jobs: remainingJobs }
       });
@@ -265,6 +265,43 @@ class JobActivityPage extends LitElement {
   
   handleDateFilter(e) {
     this.dateFilter = e.target.value;
+  }
+
+  async handleDeleteJob(e) {
+    const job = e.detail?.job;
+    if (!job?.id) return;
+
+    const confirmed = confirm(`Delete "${job.displayName}"? This action cannot be undone.`);
+    if (!confirmed) return;
+
+    try {
+      await deleteJob(job.id);
+      store.updateState({
+        jobsContext: {
+          jobs: store.jobsContext.jobs.filter(existingJob => existingJob.id !== job.id)
+        }
+      });
+    } catch (err) {
+      console.error('Failed to delete job:', err);
+      alert('Failed to delete job. Please try again.');
+    }
+  }
+
+  async handleRetryJob(e) {
+    const job = e.detail?.job;
+    if (!job?.id) return;
+
+    try {
+      await retryJob(job.id);
+      store.updateState({
+        jobsContext: {
+          jobs: store.jobsContext.jobs.filter(existingJob => existingJob.id !== job.id)
+        }
+      });
+    } catch (err) {
+      console.error('Failed to retry job:', err);
+      alert('Failed to retry job. Please try again.');
+    }
   }
   
   filterJobs(jobs) {
@@ -336,6 +373,8 @@ class JobActivityPage extends LitElement {
               id="job-${job.id}"
               .job=${job}
               ?initiallyExpanded=${job.id === targetJobId}
+              @job-delete=${this.handleDeleteJob}
+              @job-retry=${this.handleRetryJob}
             ></job-progress>
           `)}
           
@@ -358,7 +397,7 @@ class JobActivityPage extends LitElement {
     const activeJobs = filteredJobs.filter(j => j.status === 'in_progress');
     const pendingJobs = filteredJobs.filter(j => j.status === 'queued');
     const completedJobs = filteredJobs
-      .filter(j => ['completed', 'failed', 'cancelled'].includes(j.status))
+      .filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status))
       .sort((a, b) => new Date(b.finished || b.started) - new Date(a.finished || a.started));
     
     return html`
@@ -391,6 +430,7 @@ class JobActivityPage extends LitElement {
               <sl-option value="completed">Completed</sl-option>
               <sl-option value="failed">Failed</sl-option>
               <sl-option value="cancelled">Cancelled</sl-option>
+              <sl-option value="orphaned">Orphaned</sl-option>
             </sl-select>
           </div>
           
@@ -427,7 +467,7 @@ class JobActivityPage extends LitElement {
         )}
         
         ${this.renderSection(
-          'Recently Completed Jobs',
+          'Recent Finished Jobs',
           completedJobs,
           this.showCompletedLimit,
           () => this.showMoreCompleted(),

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -2,7 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
 import { clearCompletedJobs, deleteJob } from '/api/jobs/jobs.js';
-import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isFinishedJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -231,7 +231,7 @@ class JobActivityPage extends LitElement {
   
   async handleClearCompleted() {
     const { jobs } = store.jobsContext;
-    const completedCount = jobs.filter((j) => isTerminalJobStatus(j.status)).length;
+    const completedCount = jobs.filter((j) => isFinishedJobStatus(j.status)).length;
     
     if (completedCount === 0) {
       alert('No finished jobs to clear.');
@@ -380,7 +380,7 @@ class JobActivityPage extends LitElement {
     const activeJobs = filteredJobs.filter(j => j.status === 'in_progress');
     const pendingJobs = filteredJobs.filter(j => j.status === 'queued');
     const completedJobs = filteredJobs
-      .filter((j) => isTerminalJobStatus(j.status))
+      .filter((j) => isFinishedJobStatus(j.status))
       .sort((a, b) => new Date(b.finished || b.started) - new Date(a.finished || a.started));
     
     return html`

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -2,7 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
 import { clearCompletedJobs, deleteJob } from '/api/jobs/jobs.js';
-import { isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -246,7 +246,7 @@ class JobActivityPage extends LitElement {
       await clearCompletedJobs(0);
       
       // Update local state
-      const remainingJobs = jobs.filter((j) => !isTerminalJobStatus(j.status));
+      const remainingJobs = jobs.filter((j) => isActiveJobStatus(j.status));
       store.updateState({
         jobsContext: { jobs: remainingJobs }
       });

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -2,6 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
 import { clearCompletedJobs, deleteJob, retryJob } from '/api/jobs/jobs.js';
+import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -230,7 +231,7 @@ class JobActivityPage extends LitElement {
   
   async handleClearCompleted() {
     const { jobs } = store.jobsContext;
-    const completedCount = jobs.filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status)).length;
+    const completedCount = jobs.filter((j) => isTerminalJobStatus(j.status)).length;
     
     if (completedCount === 0) {
       alert('No finished jobs to clear.');
@@ -245,7 +246,7 @@ class JobActivityPage extends LitElement {
       await clearCompletedJobs(0);
       
       // Update local state
-      const remainingJobs = jobs.filter(j => !['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status));
+      const remainingJobs = jobs.filter((j) => !isTerminalJobStatus(j.status));
       store.updateState({
         jobsContext: { jobs: remainingJobs }
       });
@@ -309,10 +310,10 @@ class JobActivityPage extends LitElement {
     
     // Apply search filter
     if (this.searchQuery) {
-      filtered = filtered.filter(job =>
-        job.displayName.toLowerCase().includes(this.searchQuery) ||
-        job.summaryMessage.toLowerCase().includes(this.searchQuery) ||
-        (job.errorMessage && job.errorMessage.toLowerCase().includes(this.searchQuery))
+      filtered = filtered.filter((job) =>
+        (job.displayName || '').toLowerCase().includes(this.searchQuery) ||
+        (job.summaryMessage || '').toLowerCase().includes(this.searchQuery) ||
+        (job.errorMessage || '').toLowerCase().includes(this.searchQuery)
       );
     }
     
@@ -397,7 +398,7 @@ class JobActivityPage extends LitElement {
     const activeJobs = filteredJobs.filter(j => j.status === 'in_progress');
     const pendingJobs = filteredJobs.filter(j => j.status === 'queued');
     const completedJobs = filteredJobs
-      .filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status))
+      .filter((j) => isTerminalJobStatus(j.status))
       .sort((a, b) => new Date(b.finished || b.started) - new Date(a.finished || a.started));
     
     return html`

--- a/src/utils/devtools/debug-panel.js
+++ b/src/utils/devtools/debug-panel.js
@@ -10,6 +10,7 @@ import { bindToClass } from "/utils/class-bind.js";
 import * as devToolFunctions from "./functions/index.js";
 import "./debug-settings.js";
 import { checkPupUpdates } from '/api/pup-updates/pup-updates.js';
+import { createOrphanedJobCandidate } from '/api/jobs/jobs.js';
 import { pupUpdates } from '/state/pup-updates.js';
 import { store } from '/state/store.js';
 
@@ -233,6 +234,41 @@ class DebugPanel extends LitElement {
     }
   }
 
+  async createOrphanedJob() {
+    if (store.networkContext.useMocks) {
+      alert('Create Orphaned Job requires the real backend. Disable Network Mocks first.');
+      return;
+    }
+
+    try {
+      const result = await createOrphanedJobCandidate();
+      const alert = Object.assign(document.createElement('sl-alert'), {
+        variant: 'success',
+        duration: 5000,
+        closable: true
+      });
+      alert.innerHTML = `
+        <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+        Created orphan candidate job ${result?.job?.id || ''}. It will be marked orphaned on the next detector pass.
+      `;
+      document.body.appendChild(alert);
+      alert.toast();
+    } catch (error) {
+      console.error('Failed to create orphaned job candidate:', error);
+      const alert = Object.assign(document.createElement('sl-alert'), {
+        variant: 'danger',
+        duration: 5000,
+        closable: true
+      });
+      alert.innerHTML = `
+        <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+        Failed to create orphaned job candidate: ${error.message}
+      `;
+      document.body.appendChild(alert);
+      alert.toast();
+    }
+  }
+
   async clearAllJobs() {
     const { store } = await import('/state/store.js');
     
@@ -255,7 +291,7 @@ class DebugPanel extends LitElement {
       await clearCompletedJobs(0);
       
       const remainingJobs = store.jobsContext.jobs.filter(
-        a => !['completed', 'failed', 'cancelled'].includes(a.status)
+        a => !['completed', 'failed', 'cancelled', 'orphaned'].includes(a.status)
       );
       store.updateState({
         jobsContext: { jobs: remainingJobs }
@@ -303,6 +339,11 @@ class DebugPanel extends LitElement {
                     <sl-menu-label>Jobs (Mock Only)</sl-menu-label>
                     <sl-menu-item @click=${this.createMockJob}>Create Mock Job</sl-menu-item>
                     <sl-menu-item @click=${this.clearAllJobs}>Clear All Jobs</sl-menu-item>
+                    <sl-divider></sl-divider>
+                    <sl-menu-label>Jobs (Backend Dev Mode)</sl-menu-label>
+                    <sl-menu-item @click=${this.createOrphanedJob}>Create Orphaned Job</sl-menu-item>
+                    <sl-divider></sl-divider>
+                    <sl-menu-label>Jobs</sl-menu-label>
                     <sl-menu-item @click=${this.clearCompletedJobs}>Clear Completed Jobs</sl-menu-item>
                     <sl-divider></sl-divider>
                     <sl-menu-label>Synethic Events</sl-menu-label>

--- a/src/utils/devtools/debug-panel.js
+++ b/src/utils/devtools/debug-panel.js
@@ -11,6 +11,7 @@ import * as devToolFunctions from "./functions/index.js";
 import "./debug-settings.js";
 import { checkPupUpdates } from '/api/pup-updates/pup-updates.js';
 import { createOrphanedJobCandidate } from '/api/jobs/jobs.js';
+import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 import { pupUpdates } from '/state/pup-updates.js';
 import { store } from '/state/store.js';
 
@@ -291,7 +292,7 @@ class DebugPanel extends LitElement {
       await clearCompletedJobs(0);
       
       const remainingJobs = store.jobsContext.jobs.filter(
-        a => !['completed', 'failed', 'cancelled', 'orphaned'].includes(a.status)
+        (a) => !isTerminalJobStatus(a.status)
       );
       store.updateState({
         jobsContext: { jobs: remainingJobs }

--- a/src/utils/devtools/debug-panel.js
+++ b/src/utils/devtools/debug-panel.js
@@ -11,7 +11,7 @@ import * as devToolFunctions from "./functions/index.js";
 import "./debug-settings.js";
 import { checkPupUpdates } from '/api/pup-updates/pup-updates.js';
 import { createOrphanedJobCandidate } from '/api/jobs/jobs.js';
-import { isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus } from '/controllers/jobs/status.js';
 import { pupUpdates } from '/state/pup-updates.js';
 import { store } from '/state/store.js';
 
@@ -292,7 +292,7 @@ class DebugPanel extends LitElement {
       await clearCompletedJobs(0);
       
       const remainingJobs = store.jobsContext.jobs.filter(
-        (a) => !isTerminalJobStatus(a.status)
+        (a) => isActiveJobStatus(a.status)
       );
       store.updateState({
         jobsContext: { jobs: remainingJobs }


### PR DESCRIPTION
### Adds support for orphaned jobs in the frontend.
Jobs that are marked orphaned by the backend are now shown clearly in the activity UI, rather than continuing to look like active or pending work. This makes it easier to spot stuck jobs and take the right follow-up action.

A delete option has also been added to job rows, shown when allowed.

### New features
- Show orphaned as a distinct job status in the activity page
- Add delete actions to job rows, shown when allowed
- Handle websocket updates for orphaned and deleted jobs so the UI stays in sync
- Align mock websocket payloads with the real backend event shape
- Clean up job websocket handling to use the current backend event shape directly
- Include orphaned jobs in filtering and finished-job handling in the activity page
- Add a devtools command to create an orphan candidate against the real backend for testing
- Treat orphaned jobs consistently across job-driven flows in the UI


**Backend PR** - https://github.com/Dogebox-WG/dogeboxd/pull/208