### PR TITLE
fix: pup source icon misalignment

### DIFF
--- a/src/components/views/card-pup-install/index.js
+++ b/src/components/views/card-pup-install/index.js
@@ -313,7 +313,7 @@ class PupInstallCard extends LitElement {
       font-size: 0.85rem;
       color: #b5a1ff;
     }
-    span.source sl-icon { position: relative; top: 2px; }
+    span.source sl-icon { position: relative; top: -1px; }
   `;
 }
 


### PR DESCRIPTION
Moved the relative position of the top of the icon from 2px to -1px to better visually align it with the source text.

fixes https://github.com/Dogebox-WG/dpanel/issues/220