### PR TITLE
System Upgrade Persistence - Frontend

### DIFF
--- a/src/api/bootstrap/bootstrap.mocks.v2.js
+++ b/src/api/bootstrap/bootstrap.mocks.v2.js
@@ -93,7 +93,13 @@ function generateAssetsV2(states, pupDefinitions = []) {
 }
 
 function generateSetupFacts() {
-  return { hasCompletedInitialConfiguration: true, hasConfiguredNetwork: true, hasGeneratedKey: true };
+  return {
+    hasCompletedInitialConfiguration: true,
+    hasConfiguredNetwork: true,
+    hasGeneratedKey: true,
+    activeSystemUpdateJobId: "",
+    activeSystemUpdateStatus: "",
+  };
 }
 
 function generateRandomStatsV2(states, manifests) {

--- a/src/api/jobs/jobs.js
+++ b/src/api/jobs/jobs.js
@@ -33,14 +33,6 @@ export async function deleteJob(jobId) {
   )();
 }
 
-// POST retry specific job
-export async function retryJob(jobId) {
-  return useMock(
-    () => mockJobApi.retryJob(jobId),
-    () => client.post(`/jobs/${jobId}/retry`, {})
-  )();
-}
-
 // POST create orphaned job candidate
 export async function createOrphanedJobCandidate() {
   return useMock(

--- a/src/api/jobs/jobs.js
+++ b/src/api/jobs/jobs.js
@@ -25,6 +25,30 @@ export async function getJob(jobId) {
   )();
 }
 
+// DELETE specific job
+export async function deleteJob(jobId) {
+  return useMock(
+    () => mockJobApi.deleteJob(jobId),
+    () => client.delete(`/jobs/${jobId}`)
+  )();
+}
+
+// POST retry specific job
+export async function retryJob(jobId) {
+  return useMock(
+    () => mockJobApi.retryJob(jobId),
+    () => client.post(`/jobs/${jobId}/retry`, {})
+  )();
+}
+
+// POST create orphaned job candidate
+export async function createOrphanedJobCandidate() {
+  return useMock(
+    () => mockJobApi.createOrphanedJobCandidate(),
+    () => client.post('/jobs/dev/create-orphan-candidate', {})
+  )();
+}
+
 
 // Clear completed jobs
 export async function clearCompletedJobs(olderThanDays = 0) {

--- a/src/api/jobs/jobs.js
+++ b/src/api/jobs/jobs.js
@@ -6,46 +6,51 @@ const client = new ApiClient(store.networkContext.apiBaseUrl);
 
 // Helper to choose mock or real
 function useMock(mockFn, realFn) {
-  return store.networkContext.useMocks ? mockFn : realFn;
+  const useMocks = store.networkContext.useMocks;
+  return useMocks ? mockFn : realFn;
 }
 
 // GET all jobs
 export async function getAllJobs() {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.getAllJobs(),
     () => client.get('/jobs')
   )();
+  return result;
 }
 
 // GET specific job
 export async function getJob(jobId) {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.getJob(jobId),
     () => client.get(`/jobs/${jobId}`)
   )();
+  return result;
 }
 
 // DELETE specific job
 export async function deleteJob(jobId) {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.deleteJob(jobId),
     () => client.delete(`/jobs/${jobId}`)
   )();
+  return result;
 }
 
 // POST create orphaned job candidate
 export async function createOrphanedJobCandidate() {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.createOrphanedJobCandidate(),
     () => client.post('/jobs/dev/create-orphan-candidate', {})
   )();
+  return result;
 }
-
 
 // Clear completed jobs
 export async function clearCompletedJobs(olderThanDays = 0) {
-  return useMock(
+  const result = await useMock(
     () => mockJobApi.clearCompletedJobs(olderThanDays),
     () => client.post('/jobs/clear-completed', { olderThanDays })
   )();
+  return result;
 }

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -1,4 +1,5 @@
 import { store } from '/state/store.js';
+import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 
 /**
  * Lightweight mock for job system
@@ -229,7 +230,7 @@ export const mockJobApi = {
   clearCompletedJobs: (olderThanDays) => {
     const cutoff = new Date(Date.now() - (olderThanDays * 24 * 60 * 60 * 1000));
     mockJobs = mockJobs.filter(j => {
-      const isCompleted = ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status);
+      const isCompleted = isTerminalJobStatus(j.status);
       if (!isCompleted) return true;
       
       const jobDate = new Date(j.finished || j.started);

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -1,5 +1,5 @@
 import { store } from '/state/store.js';
-import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isFinishedJobStatus } from '/controllers/jobs/status.js';
 
 /**
  * Lightweight mock for job system
@@ -197,8 +197,8 @@ export const mockJobApi = {
   clearCompletedJobs: (olderThanDays) => {
     const cutoff = new Date(Date.now() - (olderThanDays * 24 * 60 * 60 * 1000));
     mockJobs = mockJobs.filter(j => {
-      const isCompleted = isTerminalJobStatus(j.status);
-      if (!isCompleted) return true;
+      const isFinished = isFinishedJobStatus(j.status);
+      if (!isFinished) return true;
       
       const jobDate = new Date(j.finished || j.started);
       return jobDate >= cutoff;

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -188,40 +188,6 @@ export const mockJobApi = {
     return Promise.resolve({ success: true, deleted: id });
   },
 
-  retryJob: (id) => {
-    const originalJob = mockJobs.find(j => String(j.id) === String(id));
-    mockJobs = mockJobs.filter(j => String(j.id) !== String(id));
-
-    const newJob = {
-      id: mockJobId++,
-      started: new Date().toISOString(),
-      finished: null,
-      displayName: originalJob?.displayName || 'Retried Job',
-      progress: 0,
-      status: 'queued',
-      summaryMessage: 'Job queued',
-      errorMessage: null,
-    };
-
-    mockJobs.unshift(newJob);
-
-    if (mockJobWS) {
-      mockJobWS.send({
-        type: 'job:deleted',
-        update: { id }
-      });
-      mockJobWS.send({
-        type: 'job:created',
-        update: newJob
-      });
-      setTimeout(() => {
-        mockJobWS.simulateProgress(newJob.id);
-      }, 250);
-    }
-
-    return Promise.resolve({ success: true, id: newJob.id });
-  },
-
   createOrphanedJobCandidate: () => {
     return Promise.reject(new Error('Create orphaned job requires the real backend with Network Mocks disabled.'));
   },

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -45,8 +45,8 @@ class MockJobWebSocket {
       this.trigger('open');
       // Send initial jobs
       this.send({
-        type: 'initial',
-        data: mockJobs
+        type: 'bootstrap',
+        update: { jobs: mockJobs }
       });
     }, 100);
 
@@ -92,7 +92,7 @@ class MockJobWebSocket {
     
     this.send({
       type: 'job:created',
-      data: job
+        update: job
     });
 
     // Simulate progress after 2 seconds
@@ -104,7 +104,7 @@ class MockJobWebSocket {
   // Helper: Simulate progress updates
   simulateProgress(jobId) {
     const job = mockJobs.find(a => a.id === jobId);
-    if (!activity) return;
+    if (!job) return;
     
     if (job.status !== 'in_progress' && job.status !== 'queued') {
       return;
@@ -116,13 +116,13 @@ class MockJobWebSocket {
       job.summaryMessage = 'Starting...';
       this.send({
         type: 'job:updated',
-        data: { ...job }
+        update: { ...job }
       });
     }
 
     // Progress update loop
     const interval = setInterval(() => {
-      if (!activity || job.status !== 'in_progress') {
+      if (!job || job.status !== 'in_progress') {
         clearInterval(interval);
         return;
       }
@@ -143,7 +143,7 @@ class MockJobWebSocket {
         
         this.send({
           type: `job:${job.status}`,
-          data: { ...job }
+          update: { ...job }
         });
         
         clearInterval(interval);
@@ -151,7 +151,7 @@ class MockJobWebSocket {
         job.summaryMessage = `Processing... ${job.progress}%`;
         this.send({
           type: 'job:updated',
-          data: { ...job }
+          update: { ...job }
         });
       }
     }, 1500);
@@ -175,11 +175,61 @@ export const mockJobApi = {
     });
   },
 
+  deleteJob: (id) => {
+    const deletedJob = mockJobs.find(j => String(j.id) === String(id));
+    mockJobs = mockJobs.filter(j => String(j.id) !== String(id));
+    if (mockJobWS) {
+      mockJobWS.send({
+        type: 'job:deleted',
+        update: { id: deletedJob?.id ?? id }
+      });
+    }
+    return Promise.resolve({ success: true, deleted: id });
+  },
+
+  retryJob: (id) => {
+    const originalJob = mockJobs.find(j => String(j.id) === String(id));
+    mockJobs = mockJobs.filter(j => String(j.id) !== String(id));
+
+    const newJob = {
+      id: mockJobId++,
+      started: new Date().toISOString(),
+      finished: null,
+      displayName: originalJob?.displayName || 'Retried Job',
+      progress: 0,
+      status: 'queued',
+      summaryMessage: 'Job queued',
+      errorMessage: null,
+    };
+
+    mockJobs.unshift(newJob);
+
+    if (mockJobWS) {
+      mockJobWS.send({
+        type: 'job:deleted',
+        update: { id }
+      });
+      mockJobWS.send({
+        type: 'job:created',
+        update: newJob
+      });
+      setTimeout(() => {
+        mockJobWS.simulateProgress(newJob.id);
+      }, 250);
+    }
+
+    return Promise.resolve({ success: true, id: newJob.id });
+  },
+
+  createOrphanedJobCandidate: () => {
+    return Promise.reject(new Error('Create orphaned job requires the real backend with Network Mocks disabled.'));
+  },
+
 
   clearCompletedJobs: (olderThanDays) => {
     const cutoff = new Date(Date.now() - (olderThanDays * 24 * 60 * 60 * 1000));
     mockJobs = mockJobs.filter(j => {
-      const isCompleted = ['completed', 'failed'].includes(j.status);
+      const isCompleted = ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status);
       if (!isCompleted) return true;
       
       const jobDate = new Date(j.finished || j.started);

--- a/src/api/jobs/jobs.mocks.js
+++ b/src/api/jobs/jobs.mocks.js
@@ -1,5 +1,5 @@
 import { store } from '/state/store.js';
-import { isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
 
 /**
  * Lightweight mock for job system
@@ -107,7 +107,8 @@ class MockJobWebSocket {
     const job = mockJobs.find(a => a.id === jobId);
     if (!job) return;
     
-    if (job.status !== 'in_progress' && job.status !== 'queued') {
+    const isActive = isActiveJobStatus(job.status);
+    if (!isActive) {
       return;
     }
 

--- a/src/app.js
+++ b/src/app.js
@@ -26,6 +26,7 @@ import "/pages/index.js";
 import "/components/common/page-container.js";
 import "/components/views/prompt-welcome/index.js";
 import "/components/views/prompt-system/index.js";
+import "/components/views/x-system-upgrade-modal.js";
 
 // Components
 import "/utils/devtools/debug-panel.js";
@@ -63,6 +64,7 @@ import { pupUpdates } from "/state/pup-updates.js";
 
 // Job WebSocket
 import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+import { jobsController } from "/controllers/jobs/index.js";
 
 class DPanelApp extends LitElement {
   static properties = {
@@ -163,6 +165,7 @@ class DPanelApp extends LitElement {
 
       // Process pups
       if (res) {
+        jobsController.hydrateFromBootstrap(res?.setupFacts);
         this.pkgController.setData(res);
       }
 
@@ -248,6 +251,9 @@ class DPanelApp extends LitElement {
         <welcome-dialog></welcome-dialog>
         <x-debug-panel></x-debug-panel>
         <system-prompt ?open=${showSystemPrompt} task=${taskName}></system-prompt>
+        <x-system-upgrade-modal
+          @refresh-bootstrap-request=${() => this.fetchBootstrap()}
+        ></x-system-upgrade-modal>
       </aside>
     `;
   }

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { timeAgo, formatDateTime } from '/utils/time-format.js';
-import { isDeletableJobStatus, isRetryableJobStatus } from '/controllers/jobs/status.js';
+import { isDeletableJobStatus } from '/controllers/jobs/status.js';
 import { store } from '/state/store.js';
 import '/components/views/x-log-viewer/index.js';
 
@@ -334,22 +334,9 @@ class JobProgress extends LitElement {
     return isDeletableJobStatus(status);
   }
 
-  canRetry(status) {
-    return isRetryableJobStatus(status);
-  }
-
   handleDeleteClick(e) {
     e.stopPropagation();
     this.dispatchEvent(new CustomEvent('job-delete', {
-      detail: { job: this.job },
-      bubbles: true,
-      composed: true
-    }));
-  }
-
-  handleRetryClick(e) {
-    e.stopPropagation();
-    this.dispatchEvent(new CustomEvent('job-retry', {
       detail: { job: this.job },
       bubbles: true,
       composed: true
@@ -383,22 +370,13 @@ class JobProgress extends LitElement {
             <div class="job-percentage">${isIndeterminate ? '...' : `${progress}%`}</div>
           </div>
 
-          ${(this.canRetry(status) || this.canDelete(status)) ? html`
+          ${this.canDelete(status) ? html`
             <div class="job-actions">
-              ${this.canRetry(status) ? html`
-                <sl-icon-button
-                  name="arrow-repeat"
-                  label="Retry job"
-                  @click=${this.handleRetryClick}
-                ></sl-icon-button>
-              ` : ''}
-              ${this.canDelete(status) ? html`
-                <sl-icon-button
-                  name="trash"
-                  label="Delete job"
-                  @click=${this.handleDeleteClick}
-                ></sl-icon-button>
-              ` : ''}
+              <sl-icon-button
+                name="trash"
+                label="Delete job"
+                @click=${this.handleDeleteClick}
+              ></sl-icon-button>
             </div>
           ` : ''}
           

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { timeAgo, formatDateTime } from '/utils/time-format.js';
+import { isDeletableJobStatus, isRetryableJobStatus } from '/controllers/jobs/status.js';
 import { store } from '/state/store.js';
 import '/components/views/x-log-viewer/index.js';
 
@@ -330,11 +331,11 @@ class JobProgress extends LitElement {
   }
 
   canDelete(status) {
-    return status === 'queued';
+    return isDeletableJobStatus(status);
   }
 
   canRetry(status) {
-    return ['orphaned', 'failed', 'cancelled'].includes(status);
+    return isRetryableJobStatus(status);
   }
 
   handleDeleteClick(e) {

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -330,10 +330,6 @@ class JobProgress extends LitElement {
     return icons[status] || 'question-circle';
   }
 
-  canDelete(status) {
-    return isDeletableJobStatus(status);
-  }
-
   handleDeleteClick(e) {
     e.stopPropagation();
     this.dispatchEvent(new CustomEvent('job-delete', {
@@ -370,7 +366,7 @@ class JobProgress extends LitElement {
             <div class="job-percentage">${isIndeterminate ? '...' : `${progress}%`}</div>
           </div>
 
-          ${this.canDelete(status) ? html`
+          ${isDeletableJobStatus(status) ? html`
             <div class="job-actions">
               <sl-icon-button
                 name="trash"

--- a/src/components/common/job-progress/index.js
+++ b/src/components/common/job-progress/index.js
@@ -76,6 +76,10 @@ class JobProgress extends LitElement {
     .job-icon.failed {
       color: #ff6b6b;
     }
+
+    .job-icon.orphaned {
+      color: #f0ad4e;
+    }
     
     .job-icon.queued {
       color: #888;
@@ -147,6 +151,10 @@ class JobProgress extends LitElement {
     .progress-bar.failed {
       background: linear-gradient(90deg, #ff6b6b, #ff8787);
     }
+
+    .progress-bar.orphaned {
+      background: linear-gradient(90deg, #f0ad4e, #f7c46c);
+    }
     
     .progress-bar.queued {
       background: #555;
@@ -193,6 +201,13 @@ class JobProgress extends LitElement {
       color: #888;
       flex: 0 0 200px;
       min-width: 200px;
+    }
+
+    .job-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.25em;
+      flex: 0 0 auto;
     }
     
     .timing-item {
@@ -302,10 +317,37 @@ class JobProgress extends LitElement {
       in_progress: 'arrow-repeat',
       completed: 'check-circle-fill',
       failed: 'exclamation-triangle-fill',
+      orphaned: 'exclamation-octagon',
       queued: 'clock',
       cancelled: 'x-circle'
     };
     return icons[status] || 'question-circle';
+  }
+
+  canDelete(status) {
+    return status === 'queued';
+  }
+
+  canRetry(status) {
+    return ['orphaned', 'failed', 'cancelled'].includes(status);
+  }
+
+  handleDeleteClick(e) {
+    e.stopPropagation();
+    this.dispatchEvent(new CustomEvent('job-delete', {
+      detail: { job: this.job },
+      bubbles: true,
+      composed: true
+    }));
+  }
+
+  handleRetryClick(e) {
+    e.stopPropagation();
+    this.dispatchEvent(new CustomEvent('job-retry', {
+      detail: { job: this.job },
+      bubbles: true,
+      composed: true
+    }));
   }
   
   render() {
@@ -334,6 +376,25 @@ class JobProgress extends LitElement {
             
             <div class="job-percentage">${isIndeterminate ? '...' : `${progress}%`}</div>
           </div>
+
+          ${(this.canRetry(status) || this.canDelete(status)) ? html`
+            <div class="job-actions">
+              ${this.canRetry(status) ? html`
+                <sl-icon-button
+                  name="arrow-repeat"
+                  label="Retry job"
+                  @click=${this.handleRetryClick}
+                ></sl-icon-button>
+              ` : ''}
+              ${this.canDelete(status) ? html`
+                <sl-icon-button
+                  name="trash"
+                  label="Delete job"
+                  @click=${this.handleDeleteClick}
+                ></sl-icon-button>
+              ` : ''}
+            </div>
+          ` : ''}
           
           <div class="timing-info">
             ${started ? html`

--- a/src/components/common/job-progress/job-channel.test.js
+++ b/src/components/common/job-progress/job-channel.test.js
@@ -10,6 +10,7 @@ describe("jobWebSocket", () => {
         jobs: [
           {
             id: "job-1",
+            action: "install",
             displayName: "Tracked Job",
             status: "in_progress",
             progress: 30,
@@ -20,6 +21,7 @@ describe("jobWebSocket", () => {
           },
           {
             id: "job-2",
+            action: "install",
             displayName: "Queued Job",
             status: "queued",
             progress: 0,
@@ -29,6 +31,7 @@ describe("jobWebSocket", () => {
             finished: null,
           },
         ],
+        initialized: true,
         loading: false,
         error: null,
       },
@@ -74,6 +77,49 @@ describe("jobWebSocket", () => {
       id: "job-2",
       displayName: "Queued Job",
       status: "queued",
+    });
+  });
+
+  it("upserts created jobs instead of duplicating seeded placeholders", () => {
+    store.updateState({
+      jobsContext: {
+        jobs: [
+          ...store.jobsContext.jobs,
+          {
+            id: "job-3",
+            action: "system-update",
+            displayName: "System Update",
+            status: "queued",
+            progress: 0,
+            summaryMessage: "System update queued",
+            errorMessage: "",
+            started: new Date().toISOString(),
+            finished: null,
+          },
+        ],
+      },
+    });
+
+    jobWebSocket.handleMessage({
+      type: "job:created",
+      update: {
+        id: "job-3",
+        action: "system-update",
+        displayName: "System Update",
+        status: "in_progress",
+        progress: 25,
+        summaryMessage: "Applying upgrade",
+      },
+    });
+
+    const matchingJobs = store.jobsContext.jobs.filter((job) => job.id === "job-3");
+    expect(matchingJobs).to.have.length(1);
+    expect(matchingJobs[0]).to.include({
+      id: "job-3",
+      action: "system-update",
+      status: "in_progress",
+      progress: 25,
+      summaryMessage: "Applying upgrade",
     });
   });
 });

--- a/src/components/common/job-progress/job-channel.test.js
+++ b/src/components/common/job-progress/job-channel.test.js
@@ -1,0 +1,50 @@
+import { expect } from "../../../../dev/node_modules/@open-wc/testing";
+
+import { store } from "/state/store.js";
+import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+
+describe("jobWebSocket", () => {
+  beforeEach(() => {
+    store.updateState({
+      jobsContext: {
+        jobs: [
+          {
+            id: "job-1",
+            displayName: "Tracked Job",
+            status: "in_progress",
+            progress: 30,
+            summaryMessage: "Running",
+            errorMessage: null,
+            started: new Date().toISOString(),
+            finished: null,
+          },
+        ],
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  it("updates orphaned jobs and removes deleted jobs", () => {
+    jobWebSocket.handleMessage({
+      type: "job:orphaned",
+      update: {
+        id: "job-1",
+        status: "orphaned",
+        progress: 30,
+        summaryMessage: "Job marked as orphaned",
+        errorMessage: "Job is no longer being processed",
+      },
+    });
+
+    expect(store.jobsContext.jobs[0].status).to.equal("orphaned");
+    expect(store.jobsContext.jobs[0].errorMessage).to.equal("Job is no longer being processed");
+
+    jobWebSocket.handleMessage({
+      type: "job:deleted",
+      update: { id: "job-1" },
+    });
+
+    expect(store.jobsContext.jobs).to.deep.equal([]);
+  });
+});

--- a/src/components/common/job-progress/job-channel.test.js
+++ b/src/components/common/job-progress/job-channel.test.js
@@ -18,6 +18,16 @@ describe("jobWebSocket", () => {
             started: new Date().toISOString(),
             finished: null,
           },
+          {
+            id: "job-2",
+            displayName: "Queued Job",
+            status: "queued",
+            progress: 0,
+            summaryMessage: "Queued",
+            errorMessage: null,
+            started: new Date().toISOString(),
+            finished: null,
+          },
         ],
         loading: false,
         error: null,
@@ -25,26 +35,45 @@ describe("jobWebSocket", () => {
     });
   });
 
-  it("updates orphaned jobs and removes deleted jobs", () => {
+  it("merges orphaned job updates without disturbing other jobs", () => {
     jobWebSocket.handleMessage({
       type: "job:orphaned",
       update: {
         id: "job-1",
         status: "orphaned",
-        progress: 30,
-        summaryMessage: "Job marked as orphaned",
+        progress: 42,
+        summaryMessage: "Marked as orphaned",
         errorMessage: "Job is no longer being processed",
       },
     });
 
-    expect(store.jobsContext.jobs[0].status).to.equal("orphaned");
-    expect(store.jobsContext.jobs[0].errorMessage).to.equal("Job is no longer being processed");
+    expect(store.jobsContext.jobs[0]).to.include({
+      id: "job-1",
+      displayName: "Tracked Job",
+      status: "orphaned",
+      progress: 42,
+      summaryMessage: "Marked as orphaned",
+      errorMessage: "Job is no longer being processed",
+    });
+    expect(store.jobsContext.jobs[1]).to.include({
+      id: "job-2",
+      displayName: "Queued Job",
+      status: "queued",
+      progress: 0,
+    });
+  });
 
+  it("removes only the deleted job", () => {
     jobWebSocket.handleMessage({
       type: "job:deleted",
       update: { id: "job-1" },
     });
 
-    expect(store.jobsContext.jobs).to.deep.equal([]);
+    expect(store.jobsContext.jobs).to.have.length(1);
+    expect(store.jobsContext.jobs[0]).to.include({
+      id: "job-2",
+      displayName: "Queued Job",
+      status: "queued",
+    });
   });
 });

--- a/src/components/common/job-progress/job-progress.test.js
+++ b/src/components/common/job-progress/job-progress.test.js
@@ -3,7 +3,7 @@ import { html, fixture, expect } from "../../../../dev/node_modules/@open-wc/tes
 import "./index.js";
 
 describe("JobProgress", () => {
-  it("shows delete but not retry for queued jobs", async () => {
+  it("shows delete for queued jobs", async () => {
     const job = {
       id: "job-1",
       displayName: "Queued Job",
@@ -17,10 +17,8 @@ describe("JobProgress", () => {
 
     const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
 
-    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
     const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
 
-    expect(retryButton).to.not.exist;
     expect(deleteButton).to.exist;
 
     const deleteEventPromise = new Promise((resolve) => {
@@ -31,29 +29,18 @@ describe("JobProgress", () => {
     expect(deleteEvent.detail.job).to.equal(job);
   });
 
-  it("shows retry but not delete for failed jobs", async () => {
-    const job = {
-      id: "job-2",
-      displayName: "Failed Job",
-      status: "failed",
-      progress: 80,
-      summaryMessage: "Failed",
-      errorMessage: "Boom",
-      started: new Date().toISOString(),
-      finished: new Date().toISOString(),
-    };
-
-    const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
-
-    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
-    const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
-
-    expect(retryButton).to.exist;
-    expect(deleteButton).to.not.exist;
-  });
-
-  it("shows retry but not delete for orphaned and cancelled jobs", async () => {
+  it("does not show actions for non-queued jobs", async () => {
     const jobs = [
+      {
+        id: "job-2",
+        displayName: "Failed Job",
+        status: "failed",
+        progress: 80,
+        summaryMessage: "Failed",
+        errorMessage: "Boom",
+        started: new Date().toISOString(),
+        finished: new Date().toISOString(),
+      },
       {
         id: "job-3",
         displayName: "Orphaned Job",
@@ -79,10 +66,8 @@ describe("JobProgress", () => {
     for (const job of jobs) {
       const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
 
-      const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
       const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
 
-      expect(retryButton).to.exist;
       expect(deleteButton).to.not.exist;
     }
   });

--- a/src/components/common/job-progress/job-progress.test.js
+++ b/src/components/common/job-progress/job-progress.test.js
@@ -1,0 +1,89 @@
+import { html, fixture, expect } from "../../../../dev/node_modules/@open-wc/testing";
+
+import "./index.js";
+
+describe("JobProgress", () => {
+  it("shows delete but not retry for queued jobs", async () => {
+    const job = {
+      id: "job-1",
+      displayName: "Queued Job",
+      status: "queued",
+      progress: 0,
+      summaryMessage: "Queued",
+      errorMessage: null,
+      started: new Date().toISOString(),
+      finished: null,
+    };
+
+    const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
+
+    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
+    const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
+
+    expect(retryButton).to.not.exist;
+    expect(deleteButton).to.exist;
+
+    const deleteEventPromise = new Promise((resolve) => {
+      el.addEventListener("job-delete", resolve, { once: true });
+    });
+    deleteButton.click();
+    const deleteEvent = await deleteEventPromise;
+    expect(deleteEvent.detail.job).to.equal(job);
+  });
+
+  it("shows retry but not delete for failed jobs", async () => {
+    const job = {
+      id: "job-2",
+      displayName: "Failed Job",
+      status: "failed",
+      progress: 80,
+      summaryMessage: "Failed",
+      errorMessage: "Boom",
+      started: new Date().toISOString(),
+      finished: new Date().toISOString(),
+    };
+
+    const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
+
+    const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
+    const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
+
+    expect(retryButton).to.exist;
+    expect(deleteButton).to.not.exist;
+  });
+
+  it("shows retry but not delete for orphaned and cancelled jobs", async () => {
+    const jobs = [
+      {
+        id: "job-3",
+        displayName: "Orphaned Job",
+        status: "orphaned",
+        progress: 40,
+        summaryMessage: "Job marked as orphaned",
+        errorMessage: "Job is no longer being processed",
+        started: new Date().toISOString(),
+        finished: new Date().toISOString(),
+      },
+      {
+        id: "job-4",
+        displayName: "Cancelled Job",
+        status: "cancelled",
+        progress: 80,
+        summaryMessage: "Cancelled by user",
+        errorMessage: null,
+        started: new Date().toISOString(),
+        finished: new Date().toISOString(),
+      },
+    ];
+
+    for (const job of jobs) {
+      const el = await fixture(html`<job-progress .job=${job}></job-progress>`);
+
+      const retryButton = el.shadowRoot.querySelector('sl-icon-button[label="Retry job"]');
+      const deleteButton = el.shadowRoot.querySelector('sl-icon-button[label="Delete job"]');
+
+      expect(retryButton).to.exist;
+      expect(deleteButton).to.not.exist;
+    }
+  });
+});

--- a/src/components/common/job-progress/job-progress.test.js
+++ b/src/components/common/job-progress/job-progress.test.js
@@ -29,7 +29,7 @@ describe("JobProgress", () => {
     expect(deleteEvent.detail.job).to.equal(job);
   });
 
-  it("does not show actions for non-queued jobs", async () => {
+  it("does not show delete for non-queued jobs", async () => {
     const jobs = [
       {
         id: "job-2",

--- a/src/components/views/action-check-updates/index.js
+++ b/src/components/views/action-check-updates/index.js
@@ -299,7 +299,12 @@ export class CheckUpdatesView extends LitElement {
     return html`
       <div class="page">
 
-        <sl-button variant="text" @click=${() => { this._page = PAGE_ONE; this._confirmation_checked = false;}} class="back-button">
+        <sl-button
+          variant="text"
+          ?disabled=${this._inflight_update}
+          @click=${() => { this._page = PAGE_ONE; this._confirmation_checked = false;}}
+          class="back-button"
+        >
           Back
         </sl-button>
 
@@ -332,7 +337,12 @@ export class CheckUpdatesView extends LitElement {
 
         <div class="action-wrap">
           <sl-checkbox @sl-change=${this.handleCheckboxChange} ?disabled=${this._inflight_update}>I understand</sl-checkbox>
-          <sl-button variant="warning" ?disabled=${!this._confirmation_checked || this._inflight_update} @click=${this.handleSubmit}>
+          <sl-button
+            variant="warning"
+            ?loading=${this._inflight_update}
+            ?disabled=${!this._confirmation_checked || this._inflight_update}
+            @click=${this.handleSubmit}
+          >
             Update now
           </sl-button>
         </div>
@@ -378,7 +388,7 @@ export class CheckUpdatesView extends LitElement {
         `: nothing }
 
         ${this._inflight_update ? html`
-          <p style="line-height: 1.1"><small>This may take up to 2 minutes.<br>Do not refresh or power off your Dogebox while update is in progress.</small></p>`
+          <p style="line-height: 1.1"><small>This may take up to 2 minutes.<br>Do not power off your Dogebox while the update is in progress.</small></p>`
         : nothing }
 
         ${!this._inflight_update ? html`
@@ -406,15 +416,38 @@ export class CheckUpdatesView extends LitElement {
     this._confirmation_checked = e.target.checked;
   }
 
-  async handleSubmit() {
-    this._page = PAGE_THREE;
-    this._update_commenced = false;
-    this._inflight_update = true;
-    this._logs = [];
-    this._systemJobId = "";
-    this._update_outcome = null;
+  seedPendingSystemUpdate(jobId) {
+    if (!jobId) {
+      return;
+    }
 
-    let didErr = false;
+    const jobs = Array.isArray(store.jobsContext.jobs) ? store.jobsContext.jobs : [];
+    const started = new Date().toISOString();
+    const placeholderJob = {
+      id: jobId,
+      action: "system-update",
+      displayName: "System Update",
+      status: "queued",
+      progress: 0,
+      summaryMessage: "System update queued",
+      errorMessage: "",
+      started,
+      finished: null,
+    };
+    const hasExistingJob = jobs.some((job) => job.id === jobId);
+
+    store.updateState({
+      jobsContext: {
+        jobs: hasExistingJob
+          ? jobs.map((job) => (job.id === jobId ? { ...job, ...placeholderJob } : job))
+          : [...jobs, placeholderJob],
+      },
+    });
+  }
+
+  async handleSubmit() {
+    this._inflight_update = true;
+    this._update_outcome = null;
 
     try {
       await asyncTimeout(1000);
@@ -423,20 +456,21 @@ export class CheckUpdatesView extends LitElement {
       // this, and the UI around all our upgrades will have to be updated slightly.
       const res = await commenceUpdate("dogebox", this._updatablePackages[0].latestUpdate.version);
       this._systemJobId = res?.id || "";
+      if (!this._systemJobId) {
+        throw new Error("System update did not return a job id");
+      }
 
-      this._update_commenced = true;
+      this.seedPendingSystemUpdate(this._systemJobId);
+      store.updateState({ dialogContext: { name: null } });
+      const router = getRouter();
+      if (router) {
+        router.go("/settings", { replace: true });
+      }
     } catch (err) {
-      didErr = true;
       console.log("Update error:", err);
-      createAlert('danger', 'Failed to commence update')
+      createAlert("danger", "Failed to commence update");
       this._inflight_update = false;
-      this._update_outcome = "error"
-    }
-
-    if (!didErr) {
-      // Initiate a poll for version change.
-      // When version change is detected, flick to success screen.
-      this.pollForUpdateChange()
+      this._update_outcome = "error";
     }
   }
 

--- a/src/components/views/action-check-updates/index.js
+++ b/src/components/views/action-check-updates/index.js
@@ -151,7 +151,7 @@ export class CheckUpdatesView extends LitElement {
     const jobs = this.context?.store?.jobsContext?.jobs || [];
     const job = jobs.find(item => item.id === this._systemJobId);
     if (!job) return;
-    if (job.status === "failed" || job.status === "cancelled") {
+    if (job.status === "failed" || job.status === "cancelled" || job.status === "orphaned") {
       this.markUpdateFailed();
     }
   }

--- a/src/components/views/action-check-updates/index.js
+++ b/src/components/views/action-check-updates/index.js
@@ -15,6 +15,7 @@ import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { getBootstrapV2 } from "/api/bootstrap/bootstrap.js";
 import { pkgController } from "/controllers/package/index.js";
+import { isFailureJobStatus } from "/controllers/jobs/status.js";
 import { getRouter } from "/router/index.js";
 
 const PAGE_ONE = "checking";
@@ -151,7 +152,7 @@ export class CheckUpdatesView extends LitElement {
     const jobs = this.context?.store?.jobsContext?.jobs || [];
     const job = jobs.find(item => item.id === this._systemJobId);
     if (!job) return;
-    if (job.status === "failed" || job.status === "cancelled" || job.status === "orphaned") {
+    if (isFailureJobStatus(job.status)) {
       this.markUpdateFailed();
     }
   }

--- a/src/components/views/action-setup-progress.test.js
+++ b/src/components/views/action-setup-progress.test.js
@@ -1,0 +1,57 @@
+import { html, fixture, expect } from "../../../dev/node_modules/@open-wc/testing";
+
+import { store } from "/state/store.js";
+import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+
+import "./action-setup-progress/index.js";
+
+describe("SetupProgress", () => {
+  beforeEach(() => {
+    store.updateState({
+      networkContext: {
+        ...store.networkContext,
+        useMocks: true,
+      },
+      jobsContext: {
+        jobs: [
+          {
+            id: "job-setup-1",
+            displayName: "Setup Dogebox",
+            status: "orphaned",
+            progress: 25,
+            summaryMessage: "Job marked as orphaned",
+            errorMessage: "Job is no longer being processed",
+            started: new Date().toISOString(),
+            finished: new Date().toISOString(),
+          },
+        ],
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  afterEach(() => {
+    jobWebSocket.disconnect();
+    store.updateState({
+      jobsContext: {
+        jobs: [],
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  it("treats orphaned jobs as failed setup outcomes", async () => {
+    const el = await fixture(
+      html`<x-action-setup-progress .jobId=${"job-setup-1"}></x-action-setup-progress>`
+    );
+
+    await el.updateComplete;
+
+    expect(el._failed).to.equal(true);
+    expect(el._completionHandled).to.equal(true);
+    expect(el.shadowRoot.querySelector(".error-bar")).to.exist;
+    expect(el.shadowRoot.textContent).to.contain("Job is no longer being processed");
+  });
+});

--- a/src/components/views/action-setup-progress/index.js
+++ b/src/components/views/action-setup-progress/index.js
@@ -2,6 +2,7 @@ import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.m
 import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { jobWebSocket } from "/controllers/sockets/job-channel.js";
+import { isFailureJobStatus } from "/controllers/jobs/status.js";
 
 import "/components/views/x-log-viewer/index.js";
 
@@ -130,7 +131,7 @@ class SetupProgress extends LitElement {
       this.onSuccess && this.onSuccess();
     }
 
-    if (job.status === "failed" || job.status === "cancelled") {
+    if (isFailureJobStatus(job.status)) {
       this._completionHandled = true;
       this._failed = true;
       this._errorMessage =

--- a/src/components/views/x-system-upgrade-modal.js
+++ b/src/components/views/x-system-upgrade-modal.js
@@ -10,6 +10,11 @@ import { jobsController } from "/controllers/jobs/index.js";
 import { isFailureJobStatus } from "/controllers/jobs/status.js";
 import "/components/views/x-log-viewer/index.js";
 
+const outcomeHashes = Object.freeze({
+  success: "#system-upgrade-success",
+  error: "#system-upgrade-failed",
+});
+
 class SystemUpgradeModal extends LitElement {
   static properties = {
     activeJobId: { type: String },
@@ -39,12 +44,6 @@ class SystemUpgradeModal extends LitElement {
       font-family: "Comic Neue", sans-serif;
     }
 
-    p {
-      margin: 0;
-      color: #666;
-      line-height: 1.4;
-    }
-
     x-log-viewer {
       --log-viewer-height: 320px;
       --log-footer-height: 56px;
@@ -71,16 +70,21 @@ class SystemUpgradeModal extends LitElement {
     super.connectedCallback();
     jobsController.addObserver(this);
     window.addEventListener("beforeunload", this.handleBeforeUnload);
+    window.addEventListener("hashchange", this.handleHashChange);
+    this.restoreFinishedStateFromHash();
   }
 
   disconnectedCallback() {
     window.removeEventListener("beforeunload", this.handleBeforeUnload);
+    window.removeEventListener("hashchange", this.handleHashChange);
     jobsController.removeObserver(this);
     super.disconnectedCallback();
   }
 
   updated() {
     this.syncFinishedState();
+    this.restoreFinishedStateFromHash();
+    this.syncHashState();
   }
 
   onJobsUpdate(state) {
@@ -105,15 +109,158 @@ class SystemUpgradeModal extends LitElement {
   }
 
   getTrackedJob() {
-    const jobs = Array.isArray(this.context?.store?.jobsContext?.jobs)
-      ? this.context.store.jobsContext.jobs
-      : [];
-
     if (!this.trackedJobId) {
       return null;
     }
 
-    return jobs.find((job) => job.id === this.trackedJobId) || null;
+    return this.getSystemUpdateJobs().find((job) => job.id === this.trackedJobId) || null;
+  }
+
+  getSystemUpdateJobs() {
+    const jobs = Array.isArray(this.context?.store?.jobsContext?.jobs)
+      ? this.context.store.jobsContext.jobs
+      : [];
+
+    return jobs
+      .filter((job) => (job?.action || "").toLowerCase() === "system-update")
+      .sort((left, right) => {
+        const leftTime = Date.parse(left?.finished || left?.started || 0);
+        const rightTime = Date.parse(right?.finished || right?.started || 0);
+        return rightTime - leftTime;
+      });
+  }
+
+  parseOutcomeHash() {
+    const hash = window.location.hash || "";
+
+    for (const [outcome, prefix] of Object.entries(outcomeHashes)) {
+      if (hash === prefix) {
+        return { outcome, jobId: "" };
+      }
+
+      if (hash.startsWith(`${prefix}/`)) {
+        return {
+          outcome,
+          jobId: decodeURIComponent(hash.slice(prefix.length + 1)),
+        };
+      }
+    }
+
+    return null;
+  }
+
+  buildOutcomeHash(outcome, jobId = "") {
+    const prefix = outcomeHashes[outcome];
+    if (!prefix) {
+      return "";
+    }
+
+    return jobId ? `${prefix}/${encodeURIComponent(jobId)}` : prefix;
+  }
+
+  replaceHash(hash) {
+    const nextUrl = `${window.location.pathname}${window.location.search}${hash}`;
+    window.history.replaceState(window.history.state, "", nextUrl);
+  }
+
+  clearOutcomeHash() {
+    if (!this.parseOutcomeHash()) {
+      return;
+    }
+
+    this.replaceHash("");
+  }
+
+  shouldPreservePendingOutcomeHash() {
+    return (
+      Boolean(this.parseOutcomeHash()) &&
+      this.context?.store?.jobsContext?.initialized !== true
+    );
+  }
+
+  syncHashState() {
+    if (this.isBlocking()) {
+      this.clearOutcomeHash();
+      return;
+    }
+
+    if (!this.trackedJobId || !this.outcome) {
+      if (this.shouldPreservePendingOutcomeHash()) {
+        return;
+      }
+      this.clearOutcomeHash();
+      return;
+    }
+
+    const nextHash = this.buildOutcomeHash(this.outcome, this.trackedJobId);
+    if (window.location.hash === nextHash) {
+      return;
+    }
+
+    this.replaceHash(nextHash);
+  }
+
+  findHashTargetJob(outcome, jobId = "") {
+    const systemUpdateJobs = this.getSystemUpdateJobs();
+    const matchingStatus = outcome === "success"
+      ? (job) => job?.status === "completed"
+      : (job) => isFailureJobStatus(job?.status);
+
+    if (jobId) {
+      return systemUpdateJobs.find(
+        (job) => job.id === jobId && matchingStatus(job),
+      ) || null;
+    }
+
+    return systemUpdateJobs.find((job) => matchingStatus(job)) || null;
+  }
+
+  restoreFinishedStateFromHash() {
+    if (this.isBlocking()) {
+      return;
+    }
+
+    const hashState = this.parseOutcomeHash();
+    if (!hashState) {
+      return;
+    }
+
+    if (this.context?.store?.jobsContext?.initialized !== true) {
+      return;
+    }
+
+    const targetJob = this.findHashTargetJob(hashState.outcome, hashState.jobId);
+    if (!targetJob) {
+      return;
+    }
+
+    if (
+      this.trackedJobId === targetJob.id &&
+      this.outcome === hashState.outcome
+    ) {
+      return;
+    }
+
+    this.trackedJobId = targetJob.id;
+    this.outcome = hashState.outcome;
+  }
+
+  handleHashChange = () => {
+    if (this.isBlocking()) {
+      return;
+    }
+
+    const hashState = this.parseOutcomeHash();
+    if (!hashState) {
+      if (this.outcome) {
+        this.trackedJobId = "";
+        this.outcome = "";
+        this.requestedBootstrapRefresh = false;
+      }
+      return;
+    }
+
+    this.restoreFinishedStateFromHash();
   }
 
   syncFinishedState() {
@@ -177,6 +324,7 @@ class SystemUpgradeModal extends LitElement {
       return;
     }
 
+    this.clearOutcomeHash();
     this.trackedJobId = "";
     this.outcome = "";
     this.requestedBootstrapRefresh = false;
@@ -193,21 +341,18 @@ class SystemUpgradeModal extends LitElement {
   getStatusCopy() {
     if (this.isBlocking()) {
       return {
-        headline: "System upgrade in progress",
-        body: "Do not power off your Dogebox while the upgrade is running.",
+        headline: "System upgrade in progress, do not power off your Dogebox.",
       };
     }
 
     if (this.outcome === "success") {
       return {
         headline: "System upgrade complete",
-        body: "The system upgrade finished successfully.",
       };
     }
 
     return {
       headline: "System upgrade failed",
-      body: "The system upgrade did not complete successfully.",
     };
   }
 
@@ -228,7 +373,6 @@ class SystemUpgradeModal extends LitElement {
       >
         <div class="content">
           <h2>System Upgrade</h2>
-          <p>${copy.body}</p>
 
           <sl-alert open variant=${this.getAlertVariant()}>
             <small>${copy.headline}</small>

--- a/src/components/views/x-system-upgrade-modal.js
+++ b/src/components/views/x-system-upgrade-modal.js
@@ -1,0 +1,263 @@
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+} from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { store } from "/state/store.js";
+import { StoreSubscriber } from "/state/subscribe.js";
+import { jobsController } from "/controllers/jobs/index.js";
+import { isFailureJobStatus } from "/controllers/jobs/status.js";
+import "/components/views/x-log-viewer/index.js";
+
+class SystemUpgradeModal extends LitElement {
+  static properties = {
+    activeJobId: { type: String },
+    activeJobStatus: { type: String },
+    trackedJobId: { type: String },
+    outcome: { type: String },
+    requestedBootstrapRefresh: { type: Boolean },
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    sl-dialog::part(panel) {
+      width: min(920px, 96vw);
+    }
+
+    .content {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    h2 {
+      margin: 0;
+      font-family: "Comic Neue", sans-serif;
+    }
+
+    p {
+      margin: 0;
+      color: #666;
+      line-height: 1.4;
+    }
+
+    x-log-viewer {
+      --log-viewer-height: 320px;
+      --log-footer-height: 56px;
+    }
+
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.context = new StoreSubscriber(this, store);
+    const activeSystemUpdate = jobsController.getActiveSystemUpdate();
+    this.activeJobId = activeSystemUpdate?.id || "";
+    this.activeJobStatus = activeSystemUpdate?.status || "";
+    this.trackedJobId = this.activeJobId;
+    this.outcome = "";
+    this.requestedBootstrapRefresh = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    jobsController.addObserver(this);
+    window.addEventListener("beforeunload", this.handleBeforeUnload);
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener("beforeunload", this.handleBeforeUnload);
+    jobsController.removeObserver(this);
+    super.disconnectedCallback();
+  }
+
+  updated() {
+    this.syncFinishedState();
+  }
+
+  onJobsUpdate(state) {
+    const activeSystemUpdate = state?.activeSystemUpdate || null;
+    const nextActiveJobId = activeSystemUpdate?.id || "";
+    const nextActiveJobStatus = activeSystemUpdate?.status || "";
+
+    if (nextActiveJobId) {
+      if (nextActiveJobId !== this.trackedJobId) {
+        this.trackedJobId = nextActiveJobId;
+        this.outcome = "";
+        this.requestedBootstrapRefresh = false;
+      }
+      this.activeJobId = nextActiveJobId;
+      this.activeJobStatus = nextActiveJobStatus;
+      return;
+    }
+
+    this.activeJobId = "";
+    this.activeJobStatus = "";
+    this.syncFinishedState();
+  }
+
+  getTrackedJob() {
+    const jobs = Array.isArray(this.context?.store?.jobsContext?.jobs)
+      ? this.context.store.jobsContext.jobs
+      : [];
+
+    if (!this.trackedJobId) {
+      return null;
+    }
+
+    return jobs.find((job) => job.id === this.trackedJobId) || null;
+  }
+
+  syncFinishedState() {
+    if (this.activeJobId || !this.trackedJobId || this.outcome) {
+      return;
+    }
+
+    const trackedJob = this.getTrackedJob();
+    if (!trackedJob) {
+      return;
+    }
+
+    if (isFailureJobStatus(trackedJob.status)) {
+      this.outcome = "error";
+      return;
+    }
+
+    if (trackedJob.status === "completed") {
+      this.outcome = "success";
+      this.requestBootstrapRefresh();
+    }
+  }
+
+  requestBootstrapRefresh() {
+    if (this.requestedBootstrapRefresh) {
+      return;
+    }
+
+    this.requestedBootstrapRefresh = true;
+    this.dispatchEvent(new CustomEvent("refresh-bootstrap-request", {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  isBlocking() {
+    return Boolean(this.activeJobId);
+  }
+
+  handleBeforeUnload = (event) => {
+    if (!this.isBlocking()) {
+      return;
+    }
+
+    event.preventDefault();
+    event.returnValue = "";
+  };
+
+  handleRequestClose = (event) => {
+    event.preventDefault();
+
+    if (this.isBlocking()) {
+      return;
+    }
+
+    this.dismissFinishedModal();
+  };
+
+  dismissFinishedModal() {
+    if (this.isBlocking()) {
+      return;
+    }
+
+    this.trackedJobId = "";
+    this.outcome = "";
+    this.requestedBootstrapRefresh = false;
+  }
+
+  getAlertVariant() {
+    if (this.isBlocking()) {
+      return "warning";
+    }
+
+    return this.outcome === "success" ? "success" : "danger";
+  }
+
+  getStatusCopy() {
+    if (this.isBlocking()) {
+      return {
+        headline: "System upgrade in progress",
+        body: "Do not power off your Dogebox while the upgrade is running.",
+      };
+    }
+
+    if (this.outcome === "success") {
+      return {
+        headline: "System upgrade complete",
+        body: "The system upgrade finished successfully.",
+      };
+    }
+
+    return {
+      headline: "System upgrade failed",
+      body: "The system upgrade did not complete successfully.",
+    };
+  }
+
+  render() {
+    const open = this.isBlocking() || Boolean(this.trackedJobId && this.outcome);
+    if (!open) {
+      return nothing;
+    }
+
+    const copy = this.getStatusCopy();
+    const isBlocking = this.isBlocking();
+
+    return html`
+      <sl-dialog
+        no-header
+        ?open=${open}
+        @sl-request-close=${this.handleRequestClose}
+      >
+        <div class="content">
+          <h2>System Upgrade</h2>
+          <p>${copy.body}</p>
+
+          <sl-alert open variant=${this.getAlertVariant()}>
+            <small>${copy.headline}</small>
+            ${isBlocking
+              ? html`<sl-progress-bar indeterminate></sl-progress-bar>`
+              : html`<sl-progress-bar value="100"></sl-progress-bar>`}
+          </sl-alert>
+
+          ${this.trackedJobId
+            ? html`<x-log-viewer
+                .jobId=${this.trackedJobId}
+                autostart
+                .autoReconnect=${true}
+              ></x-log-viewer>`
+            : nothing}
+
+          ${!isBlocking
+            ? html`
+                <div class="actions">
+                  <sl-button variant="primary" @click=${this.dismissFinishedModal}>
+                    Dismiss
+                  </sl-button>
+                </div>
+              `
+            : nothing}
+        </div>
+      </sl-dialog>
+    `;
+  }
+}
+
+customElements.define("x-system-upgrade-modal", SystemUpgradeModal);

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -4,11 +4,15 @@ import { isActiveJobStatus } from "/controllers/jobs/status.js";
 class JobsController {
   constructor() {
     this.observers = new Set();
+    this.bootstrapSystemUpdate = null;
     this.state = this.deriveState(store.getContext("jobs"));
 
     store.subscribe({
       stateChanged: () => {
         const jobsContext = store.getContext("jobs");
+        if (jobsContext?.initialized) {
+          this.bootstrapSystemUpdate = null;
+        }
         const nextState = this.deriveState(jobsContext);
         const hasChanges = JSON.stringify(this.state) !== JSON.stringify(nextState);
 
@@ -22,23 +26,66 @@ class JobsController {
 
   deriveState(jobsContext = {}) {
     const jobs = Array.isArray(jobsContext?.jobs) ? jobsContext.jobs : [];
-    const activeSystemUpdate = jobs.find((job) => this.isJobPending(job, "system update"));
-    const status = ((activeSystemUpdate?.status || "").toLowerCase() || "active").replace(/_/g, " ");
+    const initialized = jobsContext?.initialized === true;
+    const activeSystemUpdate =
+      this.findActiveSystemUpdateJob(jobs) ||
+      (!initialized ? this.createBootstrapFallbackJob() : null);
+    const status = this.getDisplayStatus(activeSystemUpdate?.status);
 
     return {
       activeSystemUpdate,
+      activeSystemUpdateJobId: activeSystemUpdate?.id || "",
       isSystemUpdateLocked: Boolean(activeSystemUpdate),
       systemUpdateStatus: status,
     };
   }
 
-  isJobPending(job, matchText) {
-    const name = (job?.displayName || "").toLowerCase();
+  findActiveSystemUpdateJob(jobs = []) {
+    return jobs.find((job) => this.isSystemUpdateJobPending(job));
+  }
+
+  createBootstrapFallbackJob() {
+    if (!this.bootstrapSystemUpdate?.id) {
+      return null;
+    }
+
+    return {
+      id: this.bootstrapSystemUpdate.id,
+      action: "system-update",
+      displayName: "System Update",
+      status: this.bootstrapSystemUpdate.status,
+      progress: 0,
+      summaryMessage: "System update in progress",
+      errorMessage: "",
+    };
+  }
+
+  isSystemUpdateJobPending(job) {
+    const action = (job?.action || "").toLowerCase();
     const status = (job?.status || "").toLowerCase();
 
-    return (
-      name.includes(matchText.toLowerCase()) && isActiveJobStatus(status)
-    );
+    return action === "system-update" && isActiveJobStatus(status);
+  }
+
+  getDisplayStatus(status) {
+    return ((status || "").toLowerCase() || "active").replace(/_/g, " ");
+  }
+
+  hydrateFromBootstrap(setupFacts = {}) {
+    const jobId = setupFacts?.activeSystemUpdateJobId || "";
+    const status = (setupFacts?.activeSystemUpdateStatus || "in_progress").toLowerCase();
+
+    this.bootstrapSystemUpdate = jobId
+      ? { id: jobId, status }
+      : null;
+
+    const nextState = this.deriveState(store.getContext("jobs"));
+    const hasChanges = JSON.stringify(this.state) !== JSON.stringify(nextState);
+    this.state = nextState;
+
+    if (hasChanges) {
+      this.notifyObservers();
+    }
   }
 
   addObserver(observer) {
@@ -67,6 +114,10 @@ class JobsController {
 
   getActiveSystemUpdateStatus() {
     return this.state.systemUpdateStatus;
+  }
+
+  getActiveSystemUpdate() {
+    return this.state.activeSystemUpdate;
   }
 }
 

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -1,5 +1,5 @@
 import { store } from "/state/store.js";
-import { isTerminalJobStatus } from "/controllers/jobs/status.js";
+import { isActiveJobStatus } from "/controllers/jobs/status.js";
 
 class JobsController {
   constructor() {
@@ -37,7 +37,7 @@ class JobsController {
     const status = (job?.status || "").toLowerCase();
 
     return (
-      name.includes(matchText.toLowerCase()) && !isTerminalJobStatus(status)
+      name.includes(matchText.toLowerCase()) && isActiveJobStatus(status)
     );
   }
 

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -33,7 +33,7 @@ class JobsController {
 
   isJobPending(job, matchText) {
     const name = (job?.displayName || "").toLowerCase();
-    const statusesToIgnore = ["completed", "failed", "cancelled"];
+    const statusesToIgnore = ["completed", "failed", "cancelled", "orphaned"];
     const status = (job?.status || "").toLowerCase();
 
     return (

--- a/src/controllers/jobs/index.js
+++ b/src/controllers/jobs/index.js
@@ -1,4 +1,5 @@
 import { store } from "/state/store.js";
+import { isTerminalJobStatus } from "/controllers/jobs/status.js";
 
 class JobsController {
   constructor() {
@@ -33,11 +34,10 @@ class JobsController {
 
   isJobPending(job, matchText) {
     const name = (job?.displayName || "").toLowerCase();
-    const statusesToIgnore = ["completed", "failed", "cancelled", "orphaned"];
     const status = (job?.status || "").toLowerCase();
 
     return (
-      name.includes(matchText.toLowerCase()) && !statusesToIgnore.includes(status)
+      name.includes(matchText.toLowerCase()) && !isTerminalJobStatus(status)
     );
   }
 

--- a/src/controllers/jobs/index.test.js
+++ b/src/controllers/jobs/index.test.js
@@ -1,0 +1,75 @@
+import { expect } from "../../../dev/node_modules/@open-wc/testing";
+
+import { store } from "/state/store.js";
+import { jobsController } from "/controllers/jobs/index.js";
+
+describe("jobsController", () => {
+  beforeEach(() => {
+    jobsController.hydrateFromBootstrap({});
+    store.updateState({
+      jobsContext: {
+        jobs: [],
+        initialized: false,
+        loading: false,
+        error: null,
+      },
+    });
+  });
+
+  it("uses bootstrap system update state before jobs bootstrap arrives", () => {
+    jobsController.hydrateFromBootstrap({
+      activeSystemUpdateJobId: "system-job-1",
+      activeSystemUpdateStatus: "in_progress",
+    });
+
+    expect(jobsController.isSystemUpdateLocked()).to.equal(true);
+    expect(jobsController.getActiveSystemUpdate()).to.include({
+      id: "system-job-1",
+      action: "system-update",
+      status: "in_progress",
+    });
+  });
+
+  it("tracks active system updates by action instead of display name", () => {
+    store.updateState({
+      jobsContext: {
+        jobs: [
+          {
+            id: "system-job-2",
+            action: "system-update",
+            displayName: "Upgrade the box",
+            status: "queued",
+            progress: 0,
+            summaryMessage: "Queued",
+            errorMessage: "",
+          },
+        ],
+        initialized: true,
+      },
+    });
+
+    expect(jobsController.isSystemUpdateLocked()).to.equal(true);
+    expect(jobsController.getActiveSystemUpdateStatus()).to.equal("queued");
+    expect(jobsController.getActiveSystemUpdate()).to.include({
+      id: "system-job-2",
+      action: "system-update",
+    });
+  });
+
+  it("clears bootstrap fallback once jobs bootstrap confirms no active update", () => {
+    jobsController.hydrateFromBootstrap({
+      activeSystemUpdateJobId: "system-job-3",
+      activeSystemUpdateStatus: "queued",
+    });
+
+    store.updateState({
+      jobsContext: {
+        jobs: [],
+        initialized: true,
+      },
+    });
+
+    expect(jobsController.isSystemUpdateLocked()).to.equal(false);
+    expect(jobsController.getActiveSystemUpdate()).to.equal(null);
+  });
+});

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -5,16 +5,27 @@ export const TERMINAL_JOB_STATUSES = Object.freeze([
   "orphaned",
 ]);
 
+export const ACTIVE_JOB_STATUSES = Object.freeze([
+  "queued",
+  "in_progress",
+]);
+
 export const FAILURE_JOB_STATUSES = Object.freeze([
   "failed",
   "cancelled",
   "orphaned",
 ]);
 
-export const DELETABLE_JOB_STATUSES = Object.freeze(["queued"]);
+export const DELETABLE_JOB_STATUSES = Object.freeze([
+  "queued"
+]);
 
 export function isTerminalJobStatus(status) {
   return TERMINAL_JOB_STATUSES.includes(status);
+}
+
+export function isActiveJobStatus(status) {
+  return ACTIVE_JOB_STATUSES.includes(status);
 }
 
 export function isFailureJobStatus(status) {

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -11,12 +11,6 @@ export const FAILURE_JOB_STATUSES = Object.freeze([
   "orphaned",
 ]);
 
-export const RETRYABLE_JOB_STATUSES = Object.freeze([
-  "failed",
-  "cancelled",
-  "orphaned",
-]);
-
 export const DELETABLE_JOB_STATUSES = Object.freeze(["queued"]);
 
 export function isTerminalJobStatus(status) {
@@ -25,10 +19,6 @@ export function isTerminalJobStatus(status) {
 
 export function isFailureJobStatus(status) {
   return FAILURE_JOB_STATUSES.includes(status);
-}
-
-export function isRetryableJobStatus(status) {
-  return RETRYABLE_JOB_STATUSES.includes(status);
 }
 
 export function isDeletableJobStatus(status) {

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -1,0 +1,36 @@
+export const TERMINAL_JOB_STATUSES = Object.freeze([
+  "completed",
+  "failed",
+  "cancelled",
+  "orphaned",
+]);
+
+export const FAILURE_JOB_STATUSES = Object.freeze([
+  "failed",
+  "cancelled",
+  "orphaned",
+]);
+
+export const RETRYABLE_JOB_STATUSES = Object.freeze([
+  "failed",
+  "cancelled",
+  "orphaned",
+]);
+
+export const DELETABLE_JOB_STATUSES = Object.freeze(["queued"]);
+
+export function isTerminalJobStatus(status) {
+  return TERMINAL_JOB_STATUSES.includes(status);
+}
+
+export function isFailureJobStatus(status) {
+  return FAILURE_JOB_STATUSES.includes(status);
+}
+
+export function isRetryableJobStatus(status) {
+  return RETRYABLE_JOB_STATUSES.includes(status);
+}
+
+export function isDeletableJobStatus(status) {
+  return DELETABLE_JOB_STATUSES.includes(status);
+}

--- a/src/controllers/jobs/status.js
+++ b/src/controllers/jobs/status.js
@@ -1,4 +1,4 @@
-export const TERMINAL_JOB_STATUSES = Object.freeze([
+export const FINISHED_JOB_STATUSES = Object.freeze([
   "completed",
   "failed",
   "cancelled",
@@ -20,8 +20,8 @@ export const DELETABLE_JOB_STATUSES = Object.freeze([
   "queued"
 ]);
 
-export function isTerminalJobStatus(status) {
-  return TERMINAL_JOB_STATUSES.includes(status);
+export function isFinishedJobStatus(status) {
+  return FINISHED_JOB_STATUSES.includes(status);
 }
 
 export function isActiveJobStatus(status) {

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -1,5 +1,6 @@
 import { postConfig } from "/api/config/config.js";
 import { pickAndPerformPupAction } from "/api/action/action.js";
+import { isTerminalJobStatus } from "/controllers/jobs/status.js";
 import { store } from "/state/store.js";
 
 class PkgController {
@@ -547,12 +548,8 @@ class PkgController {
   getJobsForPup(pupId) {
     // Get active jobs for this pup (enable/disable/install/etc)
     const jobs = store?.jobsContext?.jobs || [];
-    const activeJobs = jobs.filter(j => 
-      j.pupID === pupId && 
-      j.status !== 'completed' && 
-      j.status !== 'failed' && 
-      j.status !== 'cancelled' &&
-      j.status !== 'orphaned'
+    const activeJobs = jobs.filter(
+      (j) => j.pupID === pupId && !isTerminalJobStatus(j.status)
     );
     return activeJobs;
   }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -551,7 +551,8 @@ class PkgController {
       j.pupID === pupId && 
       j.status !== 'completed' && 
       j.status !== 'failed' && 
-      j.status !== 'cancelled'
+      j.status !== 'cancelled' &&
+      j.status !== 'orphaned'
     );
     return activeJobs;
   }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -1,6 +1,6 @@
 import { postConfig } from "/api/config/config.js";
 import { pickAndPerformPupAction } from "/api/action/action.js";
-import { isTerminalJobStatus } from "/controllers/jobs/status.js";
+import { isActiveJobStatus } from "/controllers/jobs/status.js";
 import { store } from "/state/store.js";
 
 class PkgController {
@@ -549,7 +549,7 @@ class PkgController {
     // Get active jobs for this pup (enable/disable/install/etc)
     const jobs = store?.jobsContext?.jobs || [];
     const activeJobs = jobs.filter(
-      (j) => j.pupID === pupId && !isTerminalJobStatus(j.status)
+      (j) => j.pupID === pupId && isActiveJobStatus(j.status)
     );
     return activeJobs;
   }
@@ -571,7 +571,7 @@ class PkgController {
 
     //Only show logs for jobs that are queued or in progress.
     const mostRecent = sorted[0];
-    const isActive = mostRecent.status === 'queued' || mostRecent.status === 'in_progress';
+    const isActive = isActiveJobStatus(mostRecent.status);
     if (isActive) {
       return mostRecent;
     }

--- a/src/controllers/sockets/job-channel.js
+++ b/src/controllers/sockets/job-channel.js
@@ -116,13 +116,11 @@ class JobWebSocketService {
         this.handleJobCreated(update);
         break;
       case 'job:updated':
-        this.handleJobUpdated(update);
-        break;
       case 'job:completed':
       case 'job:failed':
       case 'job:cancelled':
       case 'job:orphaned':
-        this.handleJobFinished(update);
+        this.handleJobUpdated(update);
         break;
       case 'job:deleted':
         this.handleJobDeleted(update);
@@ -156,15 +154,6 @@ class JobWebSocketService {
   }
 
   handleJobUpdated(job) {
-    const jobs = store.jobsContext.jobs.map(j =>
-      j.id === job.id ? { ...j, ...job } : j
-    );
-    store.updateState({
-      jobsContext: { jobs }
-    });
-  }
-
-  handleJobFinished(job) {
     const jobs = store.jobsContext.jobs.map(j =>
       j.id === job.id ? { ...j, ...job } : j
     );

--- a/src/controllers/sockets/job-channel.js
+++ b/src/controllers/sockets/job-channel.js
@@ -19,6 +19,12 @@ class JobWebSocketService {
     const { useMocks, wsApiBaseUrl } = store.networkContext;
     this.isMockMode = useMocks;
 
+    if (!store.jobsContext.initialized) {
+      store.updateState({
+        jobsContext: { loading: true }
+      });
+    }
+
     if (this.ws) {
       if (this.isMockMode && this.ws.connected) {
         return;
@@ -48,7 +54,7 @@ class JobWebSocketService {
         console.warn('[Job WS] Backend job system not available yet');
         // Set empty jobs state
         store.updateState({
-          jobsContext: { jobs: [], loading: false }
+          jobsContext: { jobs: [], loading: false, initialized: true }
         });
       }
     }
@@ -91,7 +97,7 @@ class JobWebSocketService {
         this.attemptReconnect();
       } else {
         store.updateState({
-          jobsContext: { jobs: [], loading: false }
+          jobsContext: { jobs: [], loading: false, initialized: true }
         });
       }
     };
@@ -135,6 +141,7 @@ class JobWebSocketService {
     store.updateState({
       jobsContext: { 
         jobs: Array.isArray(jobs) ? jobs : [],
+        initialized: true,
         loading: false 
       }
     });
@@ -147,16 +154,22 @@ class JobWebSocketService {
   }
 
   handleJobCreated(job) {
-    const jobs = [...store.jobsContext.jobs, job];
+    const existingJobs = Array.isArray(store.jobsContext.jobs) ? store.jobsContext.jobs : [];
+    const existingIndex = existingJobs.findIndex((item) => item.id === job?.id);
+    const jobs = existingIndex === -1
+      ? [...existingJobs, job]
+      : existingJobs.map((item, index) => (index === existingIndex ? { ...item, ...job } : item));
     store.updateState({
       jobsContext: { jobs }
     });
   }
 
   handleJobUpdated(job) {
-    const jobs = store.jobsContext.jobs.map(j =>
-      j.id === job.id ? { ...j, ...job } : j
-    );
+    const existingJobs = Array.isArray(store.jobsContext.jobs) ? store.jobsContext.jobs : [];
+    const hasExistingJob = existingJobs.some((item) => item.id === job?.id);
+    const jobs = hasExistingJob
+      ? existingJobs.map((item) => (item.id === job.id ? { ...item, ...job } : item))
+      : [...existingJobs, job];
     store.updateState({
       jobsContext: { jobs }
     });

--- a/src/controllers/sockets/job-channel.js
+++ b/src/controllers/sockets/job-channel.js
@@ -91,27 +91,27 @@ class JobWebSocketService {
 
   handleMessage(message) {
     const { type, update } = message;
-    
-    // Backend sends 'update' field, not 'data'
-    const data = update;
 
     switch (type) {
       case 'bootstrap':
-        // Initial connection sends bootstrap with all jobs
-        if (data && Array.isArray(data.jobs)) {
-          this.handleInitialJobs(data.jobs);
+        if (update && Array.isArray(update.jobs)) {
+          this.handleInitialJobs(update.jobs);
         }
         break;
       case 'job:created':
-        this.handleJobCreated(data);
+        this.handleJobCreated(update);
         break;
       case 'job:updated':
-        this.handleJobUpdated(data);
+        this.handleJobUpdated(update);
         break;
       case 'job:completed':
       case 'job:failed':
       case 'job:cancelled':
-        this.handleJobFinished(data);
+      case 'job:orphaned':
+        this.handleJobFinished(update);
+        break;
+      case 'job:deleted':
+        this.handleJobDeleted(update);
         break;
       default:
         // Ignore other message types (pup updates, stats, etc.)
@@ -154,6 +154,13 @@ class JobWebSocketService {
     const jobs = store.jobsContext.jobs.map(j =>
       j.id === job.id ? { ...j, ...job } : j
     );
+    store.updateState({
+      jobsContext: { jobs }
+    });
+  }
+
+  handleJobDeleted(job) {
+    const jobs = store.jobsContext.jobs.filter(j => j.id !== job?.id);
     store.updateState({
       jobsContext: { jobs }
     });

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
-import { clearCompletedJobs, deleteJob, retryJob } from '/api/jobs/jobs.js';
+import { clearCompletedJobs, deleteJob } from '/api/jobs/jobs.js';
 import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
@@ -287,23 +287,6 @@ class JobActivityPage extends LitElement {
       alert('Failed to delete job. Please try again.');
     }
   }
-
-  async handleRetryJob(e) {
-    const job = e.detail?.job;
-    if (!job?.id) return;
-
-    try {
-      await retryJob(job.id);
-      store.updateState({
-        jobsContext: {
-          jobs: store.jobsContext.jobs.filter(existingJob => existingJob.id !== job.id)
-        }
-      });
-    } catch (err) {
-      console.error('Failed to retry job:', err);
-      alert('Failed to retry job. Please try again.');
-    }
-  }
   
   filterJobs(jobs) {
     let filtered = jobs;
@@ -375,7 +358,6 @@ class JobActivityPage extends LitElement {
               .job=${job}
               ?initiallyExpanded=${job.id === targetJobId}
               @job-delete=${this.handleDeleteJob}
-              @job-retry=${this.handleRetryJob}
             ></job-progress>
           `)}
           

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
-import { clearCompletedJobs } from '/api/jobs/jobs.js';
+import { clearCompletedJobs, deleteJob, retryJob } from '/api/jobs/jobs.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -230,14 +230,14 @@ class JobActivityPage extends LitElement {
   
   async handleClearCompleted() {
     const { jobs } = store.jobsContext;
-    const completedCount = jobs.filter(j => ['completed', 'failed', 'cancelled'].includes(j.status)).length;
+    const completedCount = jobs.filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status)).length;
     
     if (completedCount === 0) {
-      alert('No completed jobs to clear.');
+      alert('No finished jobs to clear.');
       return;
     }
     
-    const confirmed = confirm(`Clear ${completedCount} completed/failed jobs? This action cannot be undone.`);
+    const confirmed = confirm(`Clear ${completedCount} finished jobs? This includes completed, failed, cancelled, and orphaned jobs.`);
     if (!confirmed) return;
     
     try {
@@ -245,7 +245,7 @@ class JobActivityPage extends LitElement {
       await clearCompletedJobs(0);
       
       // Update local state
-      const remainingJobs = jobs.filter(j => !['completed', 'failed', 'cancelled'].includes(j.status));
+      const remainingJobs = jobs.filter(j => !['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status));
       store.updateState({
         jobsContext: { jobs: remainingJobs }
       });
@@ -265,6 +265,43 @@ class JobActivityPage extends LitElement {
   
   handleDateFilter(e) {
     this.dateFilter = e.target.value;
+  }
+
+  async handleDeleteJob(e) {
+    const job = e.detail?.job;
+    if (!job?.id) return;
+
+    const confirmed = confirm(`Delete "${job.displayName}"? This action cannot be undone.`);
+    if (!confirmed) return;
+
+    try {
+      await deleteJob(job.id);
+      store.updateState({
+        jobsContext: {
+          jobs: store.jobsContext.jobs.filter(existingJob => existingJob.id !== job.id)
+        }
+      });
+    } catch (err) {
+      console.error('Failed to delete job:', err);
+      alert('Failed to delete job. Please try again.');
+    }
+  }
+
+  async handleRetryJob(e) {
+    const job = e.detail?.job;
+    if (!job?.id) return;
+
+    try {
+      await retryJob(job.id);
+      store.updateState({
+        jobsContext: {
+          jobs: store.jobsContext.jobs.filter(existingJob => existingJob.id !== job.id)
+        }
+      });
+    } catch (err) {
+      console.error('Failed to retry job:', err);
+      alert('Failed to retry job. Please try again.');
+    }
   }
   
   filterJobs(jobs) {
@@ -336,6 +373,8 @@ class JobActivityPage extends LitElement {
               id="job-${job.id}"
               .job=${job}
               ?initiallyExpanded=${job.id === targetJobId}
+              @job-delete=${this.handleDeleteJob}
+              @job-retry=${this.handleRetryJob}
             ></job-progress>
           `)}
           
@@ -358,7 +397,7 @@ class JobActivityPage extends LitElement {
     const activeJobs = filteredJobs.filter(j => j.status === 'in_progress');
     const pendingJobs = filteredJobs.filter(j => j.status === 'queued');
     const completedJobs = filteredJobs
-      .filter(j => ['completed', 'failed', 'cancelled'].includes(j.status))
+      .filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status))
       .sort((a, b) => new Date(b.finished || b.started) - new Date(a.finished || a.started));
     
     return html`
@@ -391,6 +430,7 @@ class JobActivityPage extends LitElement {
               <sl-option value="completed">Completed</sl-option>
               <sl-option value="failed">Failed</sl-option>
               <sl-option value="cancelled">Cancelled</sl-option>
+              <sl-option value="orphaned">Orphaned</sl-option>
             </sl-select>
           </div>
           
@@ -427,7 +467,7 @@ class JobActivityPage extends LitElement {
         )}
         
         ${this.renderSection(
-          'Recently Completed Jobs',
+          'Recent Finished Jobs',
           completedJobs,
           this.showCompletedLimit,
           () => this.showMoreCompleted(),

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -2,7 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
 import { clearCompletedJobs, deleteJob } from '/api/jobs/jobs.js';
-import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isFinishedJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -231,7 +231,7 @@ class JobActivityPage extends LitElement {
   
   async handleClearCompleted() {
     const { jobs } = store.jobsContext;
-    const completedCount = jobs.filter((j) => isTerminalJobStatus(j.status)).length;
+    const completedCount = jobs.filter((j) => isFinishedJobStatus(j.status)).length;
     
     if (completedCount === 0) {
       alert('No finished jobs to clear.');
@@ -380,7 +380,7 @@ class JobActivityPage extends LitElement {
     const activeJobs = filteredJobs.filter(j => j.status === 'in_progress');
     const pendingJobs = filteredJobs.filter(j => j.status === 'queued');
     const completedJobs = filteredJobs
-      .filter((j) => isTerminalJobStatus(j.status))
+      .filter((j) => isFinishedJobStatus(j.status))
       .sort((a, b) => new Date(b.finished || b.started) - new Date(a.finished || a.started));
     
     return html`

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -2,7 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
 import { clearCompletedJobs, deleteJob } from '/api/jobs/jobs.js';
-import { isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus, isTerminalJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -246,7 +246,7 @@ class JobActivityPage extends LitElement {
       await clearCompletedJobs(0);
       
       // Update local state
-      const remainingJobs = jobs.filter((j) => !isTerminalJobStatus(j.status));
+      const remainingJobs = jobs.filter((j) => isActiveJobStatus(j.status));
       store.updateState({
         jobsContext: { jobs: remainingJobs }
       });

--- a/src/pages/page-activity/index.js
+++ b/src/pages/page-activity/index.js
@@ -2,6 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import { StoreSubscriber } from '/state/subscribe.js';
 import { store } from '/state/store.js';
 import { clearCompletedJobs, deleteJob, retryJob } from '/api/jobs/jobs.js';
+import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 import '/components/common/job-progress/index.js';
 
 class JobActivityPage extends LitElement {
@@ -230,7 +231,7 @@ class JobActivityPage extends LitElement {
   
   async handleClearCompleted() {
     const { jobs } = store.jobsContext;
-    const completedCount = jobs.filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status)).length;
+    const completedCount = jobs.filter((j) => isTerminalJobStatus(j.status)).length;
     
     if (completedCount === 0) {
       alert('No finished jobs to clear.');
@@ -245,7 +246,7 @@ class JobActivityPage extends LitElement {
       await clearCompletedJobs(0);
       
       // Update local state
-      const remainingJobs = jobs.filter(j => !['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status));
+      const remainingJobs = jobs.filter((j) => !isTerminalJobStatus(j.status));
       store.updateState({
         jobsContext: { jobs: remainingJobs }
       });
@@ -309,10 +310,10 @@ class JobActivityPage extends LitElement {
     
     // Apply search filter
     if (this.searchQuery) {
-      filtered = filtered.filter(job =>
-        job.displayName.toLowerCase().includes(this.searchQuery) ||
-        job.summaryMessage.toLowerCase().includes(this.searchQuery) ||
-        (job.errorMessage && job.errorMessage.toLowerCase().includes(this.searchQuery))
+      filtered = filtered.filter((job) =>
+        (job.displayName || '').toLowerCase().includes(this.searchQuery) ||
+        (job.summaryMessage || '').toLowerCase().includes(this.searchQuery) ||
+        (job.errorMessage || '').toLowerCase().includes(this.searchQuery)
       );
     }
     
@@ -397,7 +398,7 @@ class JobActivityPage extends LitElement {
     const activeJobs = filteredJobs.filter(j => j.status === 'in_progress');
     const pendingJobs = filteredJobs.filter(j => j.status === 'queued');
     const completedJobs = filteredJobs
-      .filter(j => ['completed', 'failed', 'cancelled', 'orphaned'].includes(j.status))
+      .filter((j) => isTerminalJobStatus(j.status))
       .sort((a, b) => new Date(b.finished || b.started) - new Date(a.finished || a.started));
     
     return html`

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -65,6 +65,7 @@ class Store {
     };
     this.jobsContext = {
       jobs: [],
+      initialized: false,
       loading: false,
       error: null,
     };

--- a/src/utils/devtools/debug-panel.js
+++ b/src/utils/devtools/debug-panel.js
@@ -10,6 +10,7 @@ import { bindToClass } from "/utils/class-bind.js";
 import * as devToolFunctions from "./functions/index.js";
 import "./debug-settings.js";
 import { checkPupUpdates } from '/api/pup-updates/pup-updates.js';
+import { createOrphanedJobCandidate } from '/api/jobs/jobs.js';
 import { pupUpdates } from '/state/pup-updates.js';
 import { store } from '/state/store.js';
 
@@ -233,6 +234,41 @@ class DebugPanel extends LitElement {
     }
   }
 
+  async createOrphanedJob() {
+    if (store.networkContext.useMocks) {
+      alert('Create Orphaned Job requires the real backend. Disable Network Mocks first.');
+      return;
+    }
+
+    try {
+      const result = await createOrphanedJobCandidate();
+      const alert = Object.assign(document.createElement('sl-alert'), {
+        variant: 'success',
+        duration: 5000,
+        closable: true
+      });
+      alert.innerHTML = `
+        <sl-icon slot="icon" name="exclamation-octagon"></sl-icon>
+        Created orphan candidate job ${result?.job?.id || ''}. It will be marked orphaned on the next detector pass.
+      `;
+      document.body.appendChild(alert);
+      alert.toast();
+    } catch (error) {
+      console.error('Failed to create orphaned job candidate:', error);
+      const alert = Object.assign(document.createElement('sl-alert'), {
+        variant: 'danger',
+        duration: 5000,
+        closable: true
+      });
+      alert.innerHTML = `
+        <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+        Failed to create orphaned job candidate: ${error.message}
+      `;
+      document.body.appendChild(alert);
+      alert.toast();
+    }
+  }
+
   async clearAllJobs() {
     const { store } = await import('/state/store.js');
     
@@ -255,7 +291,7 @@ class DebugPanel extends LitElement {
       await clearCompletedJobs(0);
       
       const remainingJobs = store.jobsContext.jobs.filter(
-        a => !['completed', 'failed', 'cancelled'].includes(a.status)
+        a => !['completed', 'failed', 'cancelled', 'orphaned'].includes(a.status)
       );
       store.updateState({
         jobsContext: { jobs: remainingJobs }
@@ -303,6 +339,11 @@ class DebugPanel extends LitElement {
                     <sl-menu-label>Jobs (Mock Only)</sl-menu-label>
                     <sl-menu-item @click=${this.createMockJob}>Create Mock Job</sl-menu-item>
                     <sl-menu-item @click=${this.clearAllJobs}>Clear All Jobs</sl-menu-item>
+                    <sl-divider></sl-divider>
+                    <sl-menu-label>Jobs (Backend Dev Mode)</sl-menu-label>
+                    <sl-menu-item @click=${this.createOrphanedJob}>Create Orphaned Job</sl-menu-item>
+                    <sl-divider></sl-divider>
+                    <sl-menu-label>Jobs</sl-menu-label>
                     <sl-menu-item @click=${this.clearCompletedJobs}>Clear Completed Jobs</sl-menu-item>
                     <sl-divider></sl-divider>
                     <sl-menu-label>Synethic Events</sl-menu-label>

--- a/src/utils/devtools/debug-panel.js
+++ b/src/utils/devtools/debug-panel.js
@@ -11,6 +11,7 @@ import * as devToolFunctions from "./functions/index.js";
 import "./debug-settings.js";
 import { checkPupUpdates } from '/api/pup-updates/pup-updates.js';
 import { createOrphanedJobCandidate } from '/api/jobs/jobs.js';
+import { isTerminalJobStatus } from '/controllers/jobs/status.js';
 import { pupUpdates } from '/state/pup-updates.js';
 import { store } from '/state/store.js';
 
@@ -291,7 +292,7 @@ class DebugPanel extends LitElement {
       await clearCompletedJobs(0);
       
       const remainingJobs = store.jobsContext.jobs.filter(
-        a => !['completed', 'failed', 'cancelled', 'orphaned'].includes(a.status)
+        (a) => !isTerminalJobStatus(a.status)
       );
       store.updateState({
         jobsContext: { jobs: remainingJobs }

--- a/src/utils/devtools/debug-panel.js
+++ b/src/utils/devtools/debug-panel.js
@@ -11,7 +11,7 @@ import * as devToolFunctions from "./functions/index.js";
 import "./debug-settings.js";
 import { checkPupUpdates } from '/api/pup-updates/pup-updates.js';
 import { createOrphanedJobCandidate } from '/api/jobs/jobs.js';
-import { isTerminalJobStatus } from '/controllers/jobs/status.js';
+import { isActiveJobStatus } from '/controllers/jobs/status.js';
 import { pupUpdates } from '/state/pup-updates.js';
 import { store } from '/state/store.js';
 
@@ -292,7 +292,7 @@ class DebugPanel extends LitElement {
       await clearCompletedJobs(0);
       
       const remainingJobs = store.jobsContext.jobs.filter(
-        (a) => !isTerminalJobStatus(a.status)
+        (a) => isActiveJobStatus(a.status)
       );
       store.updateState({
         jobsContext: { jobs: remainingJobs }


### PR DESCRIPTION
### System Upgrade modal can no longer be dismissed when an upgrade is in progress.

<img width="1246" height="995" alt="Screenshot 2026-04-16 at 12 13 21 pm" src="https://github.com/user-attachments/assets/6615b87a-ac00-4de9-84b9-2edc22e08248" />

<img width="1246" height="995" alt="Screenshot 2026-04-16 at 12 13 28 pm" src="https://github.com/user-attachments/assets/a78611e7-f777-403a-8395-93f748d6f17e" />

This keeps the system upgrade front and center while the job is active.

### New features

* Keep the System Upgrade modal open across route changes and refreshes while an upgrade is in progress
* Show upgrade logs in the modal
* Restore finished success and failure states after refresh with a return hash such as `http://localhost:8080/settings#system-upgrade-success/d33999a38a80b0bc6c26da76a59ea046`
* Allow the finished modal to be dismissed again once the upgrade has completed or failed

**Backend PR** - [Dogebox-WG/dogeboxd#210](https://github.com/Dogebox-WG/dogeboxd/pull/210)

Requires [Dogebox-WG/dpanel#225](https://github.com/Dogebox-WG/dpanel/pull/225) to be merged first.