### PR TITLE
Pup Source Improvements - Frontend

### DIFF
--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -25,6 +25,7 @@
         href: { type: String },
         gref: { type: String },
         upstreamVersions: { type: Object },
+        sourceUnavailable: { type: Boolean },
       };
     }
 
@@ -75,6 +76,9 @@
                   <small style="color: #777">v${version}</small>
                   ${this.hasUpdate ? html`
                     <sl-badge variant="primary" pill pulse>Update Available</sl-badge>
+                  ` : nothing}
+                  ${this.sourceUnavailable ? html`
+                    <sl-badge variant="warning" pill>Unavailable from Source</sl-badge>
                   ` : nothing}
                 </span>
                 <x-tag-set .tags=${upstreamVersions} highlight max=1></x-tag-set>

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -10,6 +10,7 @@ class PkgController {
   stateIndex = {}
   statsIndex = {}
   sourcesIndex = {}
+  hasLoadedSources = false
   assetIndex = {}
   activityIndex = {}
 
@@ -147,6 +148,7 @@ class PkgController {
 
   determineCalculatedVals(pup) {
     const isInstalled = !!pup.state
+    const unavailableFromSource = this.isPupUnavailableFromSource(pup)
 
     const activeActions = pup.state?.id ? this.getActionsForPup(pup.state.id) : [];
     const activeJobs = pup.state?.id ? this.getJobsForPup(pup.state.id) : [];
@@ -161,8 +163,11 @@ class PkgController {
         statusLabel: status.label,
         installationId: installation.id,
         installationLabel: installation.label,
+        unavailableFromSource,
         // Convention: /explore/:source_id/:pup_name
-        storeURL: isInstalled
+        storeURL: unavailableFromSource && !pup.def
+          ? null
+          : isInstalled
           ? `/explore/${pup.state.source.id}/${encodeURIComponent(pup.state.manifest.meta.name)}`
           : `/explore/${pup.def.source.id}/${encodeURIComponent(pup.def.key)}`,
         // Convention: /pups/:pup_id/:pup_name
@@ -176,8 +181,61 @@ class PkgController {
     return out
   }
 
+  isPupUnavailableFromSource(pup) {
+    if (!this.hasLoadedSources) return false;
+
+    const sourceId = pup?.state?.source?.id;
+    const pupName = pup?.state?.manifest?.meta?.name;
+    if (!sourceId || !pupName) return false;
+
+    // If the source itself no longer exists, treat the installed pup as unavailable
+    const sourceData = this.sourcesIndex?.[sourceId];
+    if (!sourceData) return true;
+
+    // A source refresh failure should not mark every installed pup from that source unavailable
+    if (sourceData.error) return false;
+
+    // If the source no longer includes the pup, treat the installed pup as unavailable
+    return !sourceData.pups?.[pupName];
+  }
+
   handleSourcesResponse(sources) {
     this.sourcesIndex = sources
+    this.hasLoadedSources = true
+
+    // Keep installed pups visible even if they were removed or updated underneath us.
+    // Source defs are pruned here, but installed state remains in the library.
+    const prunedPups = []
+    for (const pup of this.pups) {
+      const sourceId = pup?.def?.source?.id;
+      const defKey = pup?.def?.key;
+
+      if (!sourceId || !defKey) {
+        prunedPups.push(pup);
+        continue;
+      }
+
+      const sourceData = sources?.[sourceId];
+      if (sourceData?.error) {
+        prunedPups.push(pup);
+        continue;
+      }
+      const sourceStillHasPup = Boolean(sourceData?.pups?.[defKey]);
+
+      if (sourceStillHasPup) {
+        prunedPups.push(pup);
+        continue;
+      }
+
+      if (pup.state) {
+        prunedPups.push({
+          ...pup,
+          def: null,
+        });
+      }
+    }
+
+    this.pups = prunedPups
 
     try {
       for (const [sourceId, sourceData] of Object.entries(sources)) {
@@ -230,6 +288,11 @@ class PkgController {
           }
         }
       }
+
+      this.pups = this.pups.map((pup) => ({
+        ...pup,
+        computed: this.determineCalculatedVals(pup),
+      }));
     } catch (definitionProcessingError) {
       console.error(definitionProcessingError);
     }
@@ -258,7 +321,7 @@ class PkgController {
   }
 
   removePupsBySourceId(sourceId) {
-    this.pups = this.pups.filter(p => p.def.source.id !== sourceId);
+    this.pups = this.pups.filter(p => p?.def?.source?.id !== sourceId);
     if (this.sourcesIndex[sourceId]) {
       delete this.sourcesIndex[sourceId];
     }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -192,8 +192,18 @@ class PkgController {
     const sourceData = this.sourcesIndex?.[sourceId];
     if (!sourceData) return true;
 
-    // A source refresh failure should not mark every installed pup from that source unavailable
-    if (sourceData.error) return false;
+    if (sourceData.error) {
+      if (
+        sourceData.type === "disk" &&
+        /source path does not exist/i.test(sourceData.error)
+      ) {
+        // A configured disk source whose root path has been deleted is unavailable.
+        return true;
+      }
+
+      // Other source refresh failures should not mark every installed pup as unavailable.
+      return false;
+    }
 
     // If the source no longer includes the pup, treat the installed pup as unavailable
     return !sourceData.pups?.[pupName];

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -494,6 +494,9 @@ class PupPage extends LitElement {
     const hasWebUI = (pkg.state.webUIs || []).length > 0;
     const pinnedPups = this.context.store.sidebarContext?.pinned || [];
     const isInSidebar = pinnedPups.includes(pkg.state.id);
+    const source = pkg?.state?.source || pkg?.def?.source || null;
+    const sourceLocation = source?.location?.trim();
+    const isWebSource = /^https?:\/\//i.test(sourceLocation || "");
 
     const renderMenu = () => html`
       <action-row prefix="power" name="state" label="Enabled" ?disabled=${disableActions}>
@@ -546,6 +549,28 @@ class PupPage extends LitElement {
       <action-row prefix="box-arrow-up" name="ints" label="Interfaces" .trigger=${this.handleMenuClick}>
         Functionality this pup provides for other pups.
       </action-row>
+
+      ${sourceLocation ? html`
+        <action-row
+          prefix="link-45deg"
+          label="Source"
+          href=${isWebSource ? sourceLocation : ""}
+          target=${isWebSource ? "_blank" : "_self"}
+        >
+          <span title=${sourceLocation}>${sourceLocation}</span>
+          ${!isWebSource ? html`
+            <sl-copy-button
+              slot="suffix"
+              value=${sourceLocation}
+              title="Copy source path"
+              @click=${(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+            ></sl-copy-button>
+          ` : nothing}
+        </action-row>
+      ` : nothing}
     `
 
     const renderCareful = () => html`

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -55,6 +55,13 @@ export function renderStatus(labels, pkg, rollbackAvailable = false) {
       color: rgba(255, 255, 255, 0.7);
       font-size: 0.9rem;
     }
+
+    .status-badges {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      width: fit-content;
+    }
   `
 
   const [ brokenReason, isRecoverable ] = getBrokenReason(pkg)
@@ -80,7 +87,9 @@ export function renderStatus(labels, pkg, rollbackAvailable = false) {
     }
 
     ${unavailableFromSource ? html`
-      <sl-tag pill variant="warning">Unavailable from Source</sl-tag>
+      <div class="status-badges">
+        <sl-tag pill variant="warning">Unavailable from Source</sl-tag>
+      </div>
     ` : nothing}
 
     ${installationId === "broken"

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -5,6 +5,7 @@ import { createAlert } from "/components/common/alert.js";
 export function renderStatus(labels, pkg, rollbackAvailable = false) {
   let { statusId, statusLabel, installationId, installationLabel } = labels;
   const isInstallationLoadingStatus = ["uninstalling", "purging", "upgrading"].includes(installationId)
+  const unavailableFromSource = pkg?.computed?.unavailableFromSource;
 
   const styles = css`
     :host {
@@ -77,6 +78,10 @@ export function renderStatus(labels, pkg, rollbackAvailable = false) {
         ? html`<span class="status-label ${installationId}">${installationLabel}</span>`
         : html`<span class="status-label ${statusId}">${statusLabel}</span>`
     }
+
+    ${unavailableFromSource ? html`
+      <sl-tag pill variant="warning">Unavailable from Source</sl-tag>
+    ` : nothing}
 
     ${installationId === "broken"
       ? html`

--- a/src/pages/page-pup-library/index.js
+++ b/src/pages/page-pup-library/index.js
@@ -119,6 +119,11 @@ class LibraryView extends LitElement {
     }
   }
 
+  updatePups() {
+    this.installedList.setData(this.pkgController.pups.filter(p => p.state));
+    this.requestUpdate();
+  }
+
   handleActionsMenuSelect(event) {
     const selectedItemValue = event.detail.item.value;
     switch (selectedItemValue) {

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -71,6 +71,7 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
               version=${pkg.state.version}
               logoBase64=${pkg?.assets?.logos?.mainLogoBase64}
               status=${pkg.computed.statusLabel}
+              ?sourceUnavailable=${pkg.computed?.unavailableFromSource || false}
               .upstreamVersions=${pkg.state.manifest?.meta?.upstreamVersions || {}}
               href=${pkg.computed.libraryURL}
               gref=${pkg.computed.pupURL}

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -150,6 +150,9 @@ class PupInstallPage extends LitElement {
     if (!pkg) return;
 
     const { statusId, statusLabel, installationId, isInstalled, installationLabel } = pkg?.computed
+    const source = pkg?.def?.source || pkg?.state?.source || null;
+    const sourceLocation = source?.location?.trim();
+    const isWebSource = /^https?:\/\//i.test(sourceLocation || "");
     const popover_page = path[1];
 
     const wrapperClasses = classMap({
@@ -277,6 +280,27 @@ class PupInstallPage extends LitElement {
             <action-row prefix="box-arrow-up" name=ints label=Interfaces .trigger=${this.handleMenuClick}>
               Functionality this pup provides for other pups.
             </action-row>
+            ${sourceLocation ? html`
+              <action-row
+                prefix="link-45deg"
+                label="Source"
+                href=${isWebSource ? sourceLocation : ""}
+                target=${isWebSource ? "_blank" : "_self"}
+              >
+                <span title=${sourceLocation}>${sourceLocation}</span>
+                ${!isWebSource ? html`
+                  <sl-copy-button
+                    slot="suffix"
+                    value=${sourceLocation}
+                    title="Copy source path"
+                    @click=${(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                    }}
+                  ></sl-copy-button>
+                ` : nothing}
+              </action-row>
+            ` : nothing}
           </div>
         </section>
 

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -138,7 +138,7 @@ class StoreView extends LitElement {
     try {
       const storeListingRes = await getStoreListing()
       this.pkgController.setStoreData(storeListingRes);
-      this.packageList.setData(this.pkgController.pups);
+      this.packageList.setData(this.pkgController.pups.filter(p => p.def));
       this.checkForSourceErrors();
     } catch (err) {
       console.error(err);
@@ -151,7 +151,7 @@ class StoreView extends LitElement {
   }
 
   updatePups() {
-    this.pups = [...this.pkgController.pups];
+    this.pups = this.pkgController.pups.filter(p => p.def);
     this.checkForSourceErrors();
     this.requestUpdate('pups');
   }


### PR DESCRIPTION
### Installed pups now stay visible even when their source no longer lists them.

This keeps the pup library page aligned with the source's latest content while preserving installed pups in the pups page, marking them as `Unavailable from Source`.


**Pup unavailable from source**
<img width="1072" height="577" alt="Screenshot 2026-05-15 at 1 46 21 pm" src="https://github.com/user-attachments/assets/96cdb5ea-9ccb-4ccb-9dc3-3364fad1f817" />

**Source unavailable warning**
<img width="1888" height="1265" alt="Screenshot 2026-05-15 at 1 39 01 pm" src="https://github.com/user-attachments/assets/7cc0a0df-6227-4313-aa77-ab79610fdaac" />

**Pup detail page source row for URL**
<img width="1045" height="742" alt="Screenshot 2026-05-15 at 1 49 43 pm" src="https://github.com/user-attachments/assets/04edd189-d7f7-4087-8b14-9985626ff8dc" />

**Pup detail page source row for local file path**
<img width="1063" height="711" alt="Screenshot 2026-05-15 at 1 49 37 pm" src="https://github.com/user-attachments/assets/4698048f-8538-4128-be9e-14165a78a768" />


### New features

* Remove unavailable pups from store and source views without removing already-installed pups from the library
* Show an `Unavailable from Source` indicator on installed pup cards and installed pup details
* When a local pup source is used to install a pup then the source folder is deleted, that pup will now also show correctly as `Unavailable from Source` and the source will show a warning on the pup library page
* Pup detail pages now have a `Source` row which either links to their url, or allows their local file path to be coppied

**Backend PR** - [Dogebox-WG/dogeboxd#219](https://github.com/Dogebox-WG/dogeboxd/pull/219)