### PR TITLE
Language Setting Adjustment

### DIFF
--- a/src/components/views/action-language/index.js
+++ b/src/components/views/action-language/index.js
@@ -136,7 +136,7 @@ export class LanguageSettings extends LitElement {
     }
     
     return html`
-      <h1>Language</h1>
+      <h1>Keyboard Layout</h1>
 
       <div class="form-control">
 
@@ -144,11 +144,11 @@ export class LanguageSettings extends LitElement {
               name="keymap"
               
               required
-              label="Keymap" 
+              label="Keyboard Layout" 
               ?disabled=${this._inflight}
               data-field="keymap"
               value=${this._current_keymap}
-              help-text="What keyboard layout do you have?"
+              help-text="Choose the layout for your physical keyboard"
               hoist
               @sl-change=${this._handleKeymapInputChange}
             >

--- a/src/components/views/action-language/index.js
+++ b/src/components/views/action-language/index.js
@@ -74,7 +74,9 @@ export class LanguageSettings extends LitElement {
   async _fetch() {
     try {
       this._loading = true;
-      this._keymaps = await getKeymaps();
+      const collator = new Intl.Collator(undefined, { sensitivity: "base" });
+      const keymaps = await getKeymaps();
+      this._keymaps = [...keymaps].sort((a, b) => collator.compare(a.label, b.label));
       this._current_keymap = await getKeymap();
       this._changes.keymap = this._current_keymap;
 

--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -2,7 +2,7 @@ import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.m
 
 import { asyncTimeout } from "/utils/timeout.js";
 import { createAlert } from "/components/common/alert.js";
-import { getKeymaps, setKeymap } from "/api/system/keymaps.js";
+import { setKeymap } from "/api/system/keymaps.js";
 import { getTimezones, setTimezone } from "/api/system/timezones.js";
 import { getDisks, setStorageDisk } from "/api/disks/disks.js";
 import { setHostname } from "/api/system/hostname.js";
@@ -16,6 +16,8 @@ import { store } from "/state/store.js";
 
 // Components and styles
 import { toggledSectionStyles } from "/components/common/toggled-section.js";
+
+const DEFAULT_KEYMAP = "us";
 
 class SystemSettings extends LitElement {
   static styles = [toggledSectionStyles, css`
@@ -76,7 +78,6 @@ class SystemSettings extends LitElement {
       onBack: { type: Object },
       _loading: { type: Boolean },
       _inflight: { type: Boolean },
-      _keymaps: { type: Array },
       _timezones: { type: Array },
       _disks: { type: Array },
       _changes: { type: Object },
@@ -90,11 +91,10 @@ class SystemSettings extends LitElement {
   constructor() {
     super();
     this.onBack = null;
-    this._keymaps = [];
     this._timezones = [];
     this._disks = [];
     this._changes = {
-      keymap: 'us',
+      keymap: DEFAULT_KEYMAP,
       disk: '',
       'device-name': '',
       use_fdn_pup_binary_cache: true,
@@ -119,7 +119,6 @@ class SystemSettings extends LitElement {
   async _fetch() {
     try {
       this._loading = true;
-      this._keymaps = await getKeymaps();
       const rawTimezones = await getTimezones();
       
       // Transform and sort timezones
@@ -281,26 +280,6 @@ class SystemSettings extends LitElement {
               value=${this._changes['device-name']}
               @sl-input=${this._handleInputChange}
             ></sl-input>
-          </div>
-
-          <div class="form-control">
-            <sl-select
-              name="keymap"
-              required
-              label="Select Keyboard Layout" 
-              ?disabled=${this._inflight}
-              data-field="keymap"
-              value=${this._changes.keymap}
-              help-text="For if/when you plug in a physical keyboard"
-              @sl-change=${this._handleInputChange}
-            >
-              ${this._keymaps.map(
-                (keymap) =>
-                  html`<sl-option value=${keymap.id}
-                    >${keymap.label} ${!keymap.label.includes(keymap.id.toUpperCase()) ? `(${keymap.id.toUpperCase()})` : ''}</sl-option
-                  >`,
-              )}
-            </sl-select>
           </div>
 
           <div class="form-control">

--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -195,7 +195,7 @@ class SettingsPage extends LitElement {
   render() {
     const { updateAvailable } = store.getContext('sys')
     const dialog = store.getContext('dialog')
-    const hasSettingsDialog = ["updates", "versions", "remote-access", "import-blockchain", "language", "date-time"].includes(dialog.name);
+    const hasSettingsDialog = ["updates", "versions", "remote-access", "import-blockchain", "language", "keyboard-layout", "date-time"].includes(dialog.name);
     
     return html`
       <div class="padded">
@@ -227,8 +227,8 @@ class SettingsPage extends LitElement {
             <action-row prefix="usb-drive-fill" name="import-blockchain" label="Import Blockchain" .trigger=${this.handleMenuClick}>
               Import existing Dogecoin Core blockchain data from external drive
             </action-row>
-            <action-row prefix="keyboard" name="language" label="Language" href="/settings/language">
-              Hello? こんいちは？ Guten tag? Olá?
+            <action-row prefix="keyboard" name="keyboard-layout" label="Keyboard Layout" href="/settings/keyboard-layout">
+              Choose the right layout for your keyboard
             </action-row>
             <action-row prefix="clock" name="date-time" label="Date and Time" href="/settings/date-time">
               Where are we?  What time is it?
@@ -278,6 +278,7 @@ class SettingsPage extends LitElement {
           ["versions", () => renderVersionsDialog(store, this.handleDialogClose)],
           ["import-blockchain", () => this.renderImportBlockchainDialog()],
           ["language", () => html`<x-action-language></x-action-language>`],
+          ["keyboard-layout", () => html`<x-action-language></x-action-language>`],
           ["date-time", () => html`<x-action-date-time></x-action-date-time>`],
         ])}
       </sl-dialog>


### PR DESCRIPTION
Renames `language` to `keyboard layout` and removes it from the setup workflow.

**New settings menu item**
<img width="839" height="762" alt="Screenshot 2026-05-15 at 12 38 29 pm" src="https://github.com/user-attachments/assets/3c3617d0-bde0-4b36-ab2e-2a6cde852042" />

**New modal wording**
<img width="537" height="322" alt="Screenshot 2026-05-15 at 12 39 13 pm" src="https://github.com/user-attachments/assets/1ad28ba7-a3ef-4ff0-9710-d204766ce918" />


**Also sorts options, helpful once [this PR](https://github.com/Dogebox-WG/dogeboxd/pull/226) has been merged**

| Before   |      After      |
|----------|-------------|
|  <img width="534" height="794" alt="Screenshot 2026-05-15 at 12 40 28 pm" src="https://github.com/user-attachments/assets/1aebcf6a-d2c1-4c25-87f4-8c61de8838c6" />| <img width="537" height="783" alt="Screenshot 2026-05-15 at 12 51 00 pm" src="https://github.com/user-attachments/assets/fa9b0768-0f38-4a71-811e-84dd8763e34f" /> |