### PR TITLE
Update Customise OS Warning

### DIFF
--- a/src/pages/page-customise-os/index.js
+++ b/src/pages/page-customise-os/index.js
@@ -434,7 +434,7 @@ class PageCustomiseOS extends LitElement {
           <div class="banner-left">
             <div class="banner-subtitle">Edit your custom NixOS configuration below</div>
             ${!this.warningsDismissed ? html`
-              <div class="banner-warning">⚠️ Warning: Invalid configuration may prevent your system from booting - If you break something, edit /etc/nixos/dogebox/custom.nix manually via ssh</div>
+              <div class="banner-warning">⚠️ Warning: Invalid configuration may prevent your system from booting - If you break something, edit /opt/dogebox/nix/custom.nix manually via ssh</div>
               <div class="banner-warning">Is someone asking you to edit this file? They are probably trying to scam you</div>
               <div class="banner-warning">To dismiss this warning, add #i-know-what-im-doing to the beginning of the file</div>
             ` : nothing}


### PR DESCRIPTION
Update the custom.nix file path used in the Customise OS page warning to the path used in https://github.com/Dogebox-WG/dogeboxd/pull/216

It changes from `/etc/nixos/dogebox/custom.nix` to `/opt/dogebox/nix/custom.nix`