### PR TITLE
Filter Install Disks - Frontend

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -40,6 +40,7 @@ export default class ApiClient extends ReactiveClass {
   }
 
   async request(path, config) {
+    const shouldLogDiskDebug = path === '/system/disks' || path === '/system/install-disks'
 
     // if config.body is an empty object, remove the property.
     // this is to prevent the browser from sending an empty body to the server
@@ -73,10 +74,41 @@ export default class ApiClient extends ReactiveClass {
 
     let response, data
 
+    if (shouldLogDiskDebug) {
+      console.log('[disk-debug] api request:start', {
+        path,
+        url,
+        method: config.method,
+        hasAuthToken: !!this.networkContext.token,
+        useMocks,
+        hasMock,
+        specificMockEnabled,
+        noLogoutRedirect: config.noLogoutRedirect === true,
+      })
+    }
+
     try {
       response = await fetch(url, { ...config, headers });
     } catch (fetchErr) {
+      if (shouldLogDiskDebug) {
+        console.log('[disk-debug] api request:network-error', {
+          path,
+          url,
+          method: config.method,
+          error: fetchErr,
+        })
+      }
       throw new Error('An error occurred while fetching data, refer to network logs');
+    }
+
+    if (shouldLogDiskDebug) {
+      console.log('[disk-debug] api request:response', {
+        path,
+        url,
+        method: config.method,
+        status: response.status,
+        ok: response.ok,
+      })
     }
 
     if (response.status === 404) {
@@ -84,10 +116,16 @@ export default class ApiClient extends ReactiveClass {
     }
 
     if (response.status === 403) {
+      shouldLogDiskDebug && console.log('[disk-debug] api request:forbidden', { path, url })
       return { success: false, error: true, status: 403 }
     }
 
     if (response.status === 401) {
+      shouldLogDiskDebug && console.log('[disk-debug] api request:unauthorised', {
+        path,
+        url,
+        noLogoutRedirect: config.noLogoutRedirect === true,
+      })
       if (config.noLogoutRedirect) {
         return { success: false, error: true, status: 401 }
       } else {
@@ -106,6 +144,16 @@ export default class ApiClient extends ReactiveClass {
     } catch (jsonParseErr) {
       console.warn('Could not JSON parse response from server', jsonParseErr);
       throw new Error('Could not JSON parse response from server');
+    }
+
+    if (shouldLogDiskDebug) {
+      console.log('[disk-debug] api request:json', {
+        path,
+        url,
+        isArray: Array.isArray(data),
+        length: Array.isArray(data) ? data.length : undefined,
+        data,
+      })
     }
 
     // Return payload, unmodified.

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -40,8 +40,6 @@ export default class ApiClient extends ReactiveClass {
   }
 
   async request(path, config) {
-    const shouldLogDiskDebug = path === '/system/disks' || path === '/system/install-disks'
-
     // if config.body is an empty object, remove the property.
     // this is to prevent the browser from sending an empty body to the server
     // which is not what we want.
@@ -74,41 +72,10 @@ export default class ApiClient extends ReactiveClass {
 
     let response, data
 
-    if (shouldLogDiskDebug) {
-      console.log('[disk-debug] api request:start', {
-        path,
-        url,
-        method: config.method,
-        hasAuthToken: !!this.networkContext.token,
-        useMocks,
-        hasMock,
-        specificMockEnabled,
-        noLogoutRedirect: config.noLogoutRedirect === true,
-      })
-    }
-
     try {
       response = await fetch(url, { ...config, headers });
     } catch (fetchErr) {
-      if (shouldLogDiskDebug) {
-        console.log('[disk-debug] api request:network-error', {
-          path,
-          url,
-          method: config.method,
-          error: fetchErr,
-        })
-      }
       throw new Error('An error occurred while fetching data, refer to network logs');
-    }
-
-    if (shouldLogDiskDebug) {
-      console.log('[disk-debug] api request:response', {
-        path,
-        url,
-        method: config.method,
-        status: response.status,
-        ok: response.ok,
-      })
     }
 
     if (response.status === 404) {
@@ -116,16 +83,10 @@ export default class ApiClient extends ReactiveClass {
     }
 
     if (response.status === 403) {
-      shouldLogDiskDebug && console.log('[disk-debug] api request:forbidden', { path, url })
       return { success: false, error: true, status: 403 }
     }
 
     if (response.status === 401) {
-      shouldLogDiskDebug && console.log('[disk-debug] api request:unauthorised', {
-        path,
-        url,
-        noLogoutRedirect: config.noLogoutRedirect === true,
-      })
       if (config.noLogoutRedirect) {
         return { success: false, error: true, status: 401 }
       } else {
@@ -144,16 +105,6 @@ export default class ApiClient extends ReactiveClass {
     } catch (jsonParseErr) {
       console.warn('Could not JSON parse response from server', jsonParseErr);
       throw new Error('Could not JSON parse response from server');
-    }
-
-    if (shouldLogDiskDebug) {
-      console.log('[disk-debug] api request:json', {
-        path,
-        url,
-        isArray: Array.isArray(data),
-        length: Array.isArray(data) ? data.length : undefined,
-        data,
-      })
     }
 
     // Return payload, unmodified.

--- a/src/api/disks/disks.js
+++ b/src/api/disks/disks.js
@@ -15,11 +15,6 @@ export async function getDisks() {
     mock: getResponse,
     noLogoutRedirect: true,
   });
-  console.log("[disk-debug] getDisks response", {
-    isArray: Array.isArray(res),
-    length: Array.isArray(res) ? res.length : undefined,
-    response: res,
-  });
   return res;
 }
 
@@ -27,11 +22,6 @@ export async function getInstallDisks() {
   const res = await client.get(`/system/install-disks`, {
     mock: getInstallResponse,
     noLogoutRedirect: true,
-  });
-  console.log("[disk-debug] getInstallDisks response", {
-    isArray: Array.isArray(res),
-    length: Array.isArray(res) ? res.length : undefined,
-    response: res,
   });
   return res;
 }

--- a/src/api/disks/disks.js
+++ b/src/api/disks/disks.js
@@ -15,6 +15,11 @@ export async function getDisks() {
     mock: getResponse,
     noLogoutRedirect: true,
   });
+  console.log("[disk-debug] getDisks response", {
+    isArray: Array.isArray(res),
+    length: Array.isArray(res) ? res.length : undefined,
+    response: res,
+  });
   return res;
 }
 
@@ -22,6 +27,11 @@ export async function getInstallDisks() {
   const res = await client.get(`/system/install-disks`, {
     mock: getInstallResponse,
     noLogoutRedirect: true,
+  });
+  console.log("[disk-debug] getInstallDisks response", {
+    isArray: Array.isArray(res),
+    length: Array.isArray(res) ? res.length : undefined,
+    response: res,
   });
   return res;
 }

--- a/src/api/disks/disks.js
+++ b/src/api/disks/disks.js
@@ -1,13 +1,26 @@
 import ApiClient from "/api/client.js";
 import { store } from "/state/store.js";
 
-import { getResponse, postInstallLocationResponse, postStorageLocationResponse } from "./disks.mocks.js";
+import {
+  getInstallResponse,
+  getResponse,
+  postInstallLocationResponse,
+  postStorageLocationResponse,
+} from "./disks.mocks.js";
 
 const client = new ApiClient(store.networkContext.apiBaseUrl);
 
 export async function getDisks() {
   const res = await client.get(`/system/disks`, {
     mock: getResponse,
+    noLogoutRedirect: true,
+  });
+  return res;
+}
+
+export async function getInstallDisks() {
+  const res = await client.get(`/system/install-disks`, {
+    mock: getInstallResponse,
     noLogoutRedirect: true,
   });
   return res;

--- a/src/api/disks/disks.mocks.js
+++ b/src/api/disks/disks.mocks.js
@@ -1,39 +1,104 @@
+const disks = [
+  // Booted SD card.
+  {
+    name: "/dev/mmcblk0",
+    size: 31914983424,
+    sizePretty: "29.72 GB",
+    path: "/dev/mmcblk0",
+    label: "",
+    bootMedia: true,
+    suitability: {
+      install: { usable: true, sizeOK: true },
+      storage: { usable: true, sizeOK: false },
+      isAlreadyUsed: true,
+    },
+  },
+  // Small internal disk.
+  {
+    name: "/dev/sda",
+    size: 37580963840,
+    sizePretty: "35.00 GB",
+    path: "/dev/sda",
+    label: "",
+    bootMedia: false,
+    suitability: {
+      install: { usable: true, sizeOK: true },
+      storage: { usable: true, sizeOK: false },
+      isAlreadyUsed: true,
+    },
+  },
+  // Tiny device below the install size gate.
+  {
+    name: "/dev/mmcblk2boot0",
+    size: 4194304,
+    sizePretty: "4.00 MB",
+    path: "/dev/mmcblk2boot0",
+    label: "",
+    bootMedia: false,
+    suitability: {
+      install: { usable: true, sizeOK: false },
+      storage: { usable: true, sizeOK: false },
+      isAlreadyUsed: false,
+    },
+  },
+  // Large blank SATA install target.
+  {
+    name: "/dev/sdb",
+    size: 500107862016,
+    sizePretty: "465.76 GB",
+    path: "/dev/sdb",
+    label: "",
+    bootMedia: false,
+    suitability: {
+      install: { usable: true, sizeOK: true },
+      storage: { usable: true, sizeOK: true },
+      isAlreadyUsed: false,
+    },
+  },
+  // Loop-backed development disk.
+  {
+    name: "/dev/loop0",
+    size: 68719476736,
+    sizePretty: "64.00 GB",
+    path: "/dev/loop0",
+    label: "",
+    bootMedia: false,
+    suitability: {
+      install: { usable: true, sizeOK: true },
+      storage: { usable: true, sizeOK: false },
+      isAlreadyUsed: false,
+    },
+  },
+  // Large in-use NVMe disk.
+  {
+    name: "/dev/nvme0n1",
+    size: 1000204886016,
+    sizePretty: "931.51 GB",
+    path: "/dev/nvme0n1",
+    label: "",
+    bootMedia: false,
+    suitability: {
+      install: { usable: true, sizeOK: true },
+      storage: { usable: true, sizeOK: true },
+      isAlreadyUsed: true,
+    },
+  },
+];
+
 export const getResponse = {
   name: "/system/disks",
   group: "setup",
   method: "get",
-  res: [
-    {
-      name: "/dev/cdrom",
-      size: 5368709120,
-      sizePretty: "5.00 GB",
-      suitableInstallDisk: false,
-      suitableDataDisk: false,
-      bootMedia: true,
-    },
-    {
-      name: "/dev/sda",
-      size: 37580963840,
-      sizePretty: "35.00 GB",
-      suitableInstallDisk: false,
-      suitableDataDisk: false,
-      bootMedia: false,
-    },
-    {
-      name: "/dev/sdb",
-      size: 500107862016,
-      sizePretty: "465.76 GB",
-      suitableInstallDisk: true,
-      suitableDataDisk: true,
-    },
-    {
-      name: "/dev/nvme0n1",
-      size: 1000204886016,
-      sizePretty: "931.51 GB",
-      suitableInstallDisk: true,
-      suitableDataDisk: true,
-    },
-  ],
+  res: disks,
+};
+
+export const getInstallResponse = {
+  name: "/system/install-disks",
+  group: "setup",
+  method: "get",
+  res: disks.filter(
+    (disk) => disk.bootMedia !== true && disk?.suitability?.install?.usable && disk?.suitability?.install?.sizeOK,
+  ),
 };
 
 export const postInstallLocationResponse = {

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -367,6 +367,10 @@ class AppModeApp extends LitElement {
     this._logSetupFlow("fetchRecoveryState:response", response);
 
     if (!response.recoveryFacts) {
+      this._logSetupFlow("fetchRecoveryState:missing-recovery-facts", {
+        isLoggedIn: this.isLoggedIn,
+        response,
+      });
       // Only show alert if we're logged in
       if (this.isLoggedIn) {
         alert("Failed to fetch bootstrap.");
@@ -378,6 +382,11 @@ class AppModeApp extends LitElement {
       response.recoveryFacts.installationBootMedia ?? "ro";
     this.installationState =
       response.recoveryFacts.installationState ?? "notInstalled";
+    this._logSetupFlow("fetchRecoveryState:resolved-install-state", {
+      installationBootMedia: this.installationBootMedia,
+      installationState: this.installationState,
+      recoveryFacts: response.recoveryFacts,
+    });
     this.hasLoaded = true;
   }
 

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -367,10 +367,6 @@ class AppModeApp extends LitElement {
     this._logSetupFlow("fetchRecoveryState:response", response);
 
     if (!response.recoveryFacts) {
-      this._logSetupFlow("fetchRecoveryState:missing-recovery-facts", {
-        isLoggedIn: this.isLoggedIn,
-        response,
-      });
       // Only show alert if we're logged in
       if (this.isLoggedIn) {
         alert("Failed to fetch bootstrap.");
@@ -382,11 +378,6 @@ class AppModeApp extends LitElement {
       response.recoveryFacts.installationBootMedia ?? "ro";
     this.installationState =
       response.recoveryFacts.installationState ?? "notInstalled";
-    this._logSetupFlow("fetchRecoveryState:resolved-install-state", {
-      installationBootMedia: this.installationBootMedia,
-      installationState: this.installationState,
-      recoveryFacts: response.recoveryFacts,
-    });
     this.hasLoaded = true;
   }
 

--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -63,6 +63,18 @@ export class LocationPickerView extends LitElement {
       this.installationBootMedia === "ro" ||
       this.installationState === "notInstalled";
     this.mainDialogOpen = this.renderReady && this._fetchDisks;
+    console.log("[disk-debug] install-location willUpdate", {
+      renderReady: this.renderReady,
+      installationBootMedia: this.installationBootMedia,
+      installationState: this.installationState,
+      fetchDisks: this._fetchDisks,
+      inflightDisks: this._inflight_disks,
+      disksFetched: this._disks_fetched,
+      mainDialogOpen: this.mainDialogOpen,
+      installDiskCount: Array.isArray(this._installDisks)
+        ? this._installDisks.length
+        : undefined,
+    });
 
     if (this._fetchDisks && !this._inflight_disks && !this._disks_fetched) {
       this._inflight_disks = true;
@@ -79,9 +91,31 @@ export class LocationPickerView extends LitElement {
   }
 
   async fetchDisks() {
-    this._installDisks = await getInstallDisks();
-    this._inflight_disks = false;
-    this._disks_fetched = true;
+    console.log("[disk-debug] install-location fetchDisks:start", {
+      installationBootMedia: this.installationBootMedia,
+      installationState: this.installationState,
+    });
+    try {
+      const response = await getInstallDisks();
+      console.log("[disk-debug] install-location fetchDisks:response", {
+        isArray: Array.isArray(response),
+        length: Array.isArray(response) ? response.length : undefined,
+        response,
+      });
+      this._installDisks = response;
+    } catch (err) {
+      console.log("[disk-debug] install-location fetchDisks:error", err);
+      throw err;
+    } finally {
+      console.log("[disk-debug] install-location fetchDisks:complete", {
+        installDiskCount: Array.isArray(this._installDisks)
+          ? this._installDisks.length
+          : undefined,
+        installDisksIsArray: Array.isArray(this._installDisks),
+      });
+      this._inflight_disks = false;
+      this._disks_fetched = true;
+    }
   }
 
   connectedCallback() {
@@ -279,6 +313,15 @@ export class LocationPickerView extends LitElement {
   };
 
   renderList = () => {
+    if (!this._inflight_disks && !this._installDisks.length) {
+      console.log("[disk-debug] install-location renderList:empty", {
+        renderReady: this.renderReady,
+        installationBootMedia: this.installationBootMedia,
+        installationState: this.installationState,
+        installDisks: this._installDisks,
+      });
+    }
+
     return html`
       <div class="page">
         <sl-button
@@ -477,6 +520,11 @@ export class LocationPickerView extends LitElement {
   handleDiskSelection = (e, row) => {
     const diskName = row.getAttribute("data-name");
     const found = this._installDisks.findIndex((d) => d.name === diskName);
+    console.log("[disk-debug] install-location handleDiskSelection", {
+      diskName,
+      found,
+      installDisks: this._installDisks,
+    });
     if (found !== -1) {
       this._selected_disk_index = found;
       this._page = PAGE_THREE;
@@ -501,10 +549,15 @@ export class LocationPickerView extends LitElement {
     try {
       await asyncTimeout(3000);
       const diskName = this._installDisks[this._selected_disk_index].name;
+      console.log("[disk-debug] install-location handleSubmit:start", {
+        diskName,
+        selectedDiskIndex: this._selected_disk_index,
+      });
       const res = await postInstallToDisk({
         disk: diskName,
         secret: "yes-i-will-destroy-everything-on-this-disk",
       });
+      console.log("[disk-debug] install-location handleSubmit:response", res);
 
       createAlert("success", [
         "Installation complete",
@@ -512,6 +565,7 @@ export class LocationPickerView extends LitElement {
       ]);
     } catch (err) {
       didErr = true;
+      console.log("[disk-debug] install-location handleSubmit:error", err);
       console.log("Installation error:", err);
       createAlert("danger", "Failed to install on selected disk");
     } finally {

--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -63,18 +63,6 @@ export class LocationPickerView extends LitElement {
       this.installationBootMedia === "ro" ||
       this.installationState === "notInstalled";
     this.mainDialogOpen = this.renderReady && this._fetchDisks;
-    console.log("[disk-debug] install-location willUpdate", {
-      renderReady: this.renderReady,
-      installationBootMedia: this.installationBootMedia,
-      installationState: this.installationState,
-      fetchDisks: this._fetchDisks,
-      inflightDisks: this._inflight_disks,
-      disksFetched: this._disks_fetched,
-      mainDialogOpen: this.mainDialogOpen,
-      installDiskCount: Array.isArray(this._installDisks)
-        ? this._installDisks.length
-        : undefined,
-    });
 
     if (this._fetchDisks && !this._inflight_disks && !this._disks_fetched) {
       this._inflight_disks = true;
@@ -91,31 +79,9 @@ export class LocationPickerView extends LitElement {
   }
 
   async fetchDisks() {
-    console.log("[disk-debug] install-location fetchDisks:start", {
-      installationBootMedia: this.installationBootMedia,
-      installationState: this.installationState,
-    });
-    try {
-      const response = await getInstallDisks();
-      console.log("[disk-debug] install-location fetchDisks:response", {
-        isArray: Array.isArray(response),
-        length: Array.isArray(response) ? response.length : undefined,
-        response,
-      });
-      this._installDisks = response;
-    } catch (err) {
-      console.log("[disk-debug] install-location fetchDisks:error", err);
-      throw err;
-    } finally {
-      console.log("[disk-debug] install-location fetchDisks:complete", {
-        installDiskCount: Array.isArray(this._installDisks)
-          ? this._installDisks.length
-          : undefined,
-        installDisksIsArray: Array.isArray(this._installDisks),
-      });
-      this._inflight_disks = false;
-      this._disks_fetched = true;
-    }
+    this._installDisks = await getInstallDisks();
+    this._inflight_disks = false;
+    this._disks_fetched = true;
   }
 
   connectedCallback() {
@@ -313,15 +279,6 @@ export class LocationPickerView extends LitElement {
   };
 
   renderList = () => {
-    if (!this._inflight_disks && !this._installDisks.length) {
-      console.log("[disk-debug] install-location renderList:empty", {
-        renderReady: this.renderReady,
-        installationBootMedia: this.installationBootMedia,
-        installationState: this.installationState,
-        installDisks: this._installDisks,
-      });
-    }
-
     return html`
       <div class="page">
         <sl-button
@@ -520,11 +477,6 @@ export class LocationPickerView extends LitElement {
   handleDiskSelection = (e, row) => {
     const diskName = row.getAttribute("data-name");
     const found = this._installDisks.findIndex((d) => d.name === diskName);
-    console.log("[disk-debug] install-location handleDiskSelection", {
-      diskName,
-      found,
-      installDisks: this._installDisks,
-    });
     if (found !== -1) {
       this._selected_disk_index = found;
       this._page = PAGE_THREE;
@@ -549,15 +501,10 @@ export class LocationPickerView extends LitElement {
     try {
       await asyncTimeout(3000);
       const diskName = this._installDisks[this._selected_disk_index].name;
-      console.log("[disk-debug] install-location handleSubmit:start", {
-        diskName,
-        selectedDiskIndex: this._selected_disk_index,
-      });
-      const res = await postInstallToDisk({
+      await postInstallToDisk({
         disk: diskName,
         secret: "yes-i-will-destroy-everything-on-this-disk",
       });
-      console.log("[disk-debug] install-location handleSubmit:response", res);
 
       createAlert("success", [
         "Installation complete",
@@ -565,7 +512,6 @@ export class LocationPickerView extends LitElement {
       ]);
     } catch (err) {
       didErr = true;
-      console.log("[disk-debug] install-location handleSubmit:error", err);
       console.log("Installation error:", err);
       createAlert("danger", "Failed to install on selected disk");
     } finally {

--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -10,7 +10,7 @@ import { asyncTimeout } from "/utils/timeout.js";
 import "/components/common/action-row/action-row.js";
 import "/components/views/x-activity-log.js";
 import "/components/common/text-loader/text-loader.js";
-import { getDisks, postInstallToDisk } from "/api/disks/disks.js";
+import { getInstallDisks, postInstallToDisk } from "/api/disks/disks.js";
 import { promptPowerOff } from "/pages/page-settings/power-helpers.js";
 import { mainChannel } from "/controllers/sockets/main-channel.js";
 
@@ -79,11 +79,7 @@ export class LocationPickerView extends LitElement {
   }
 
   async fetchDisks() {
-    this._allDisks = await getDisks();
-    this._installDisks = this._allDisks.filter(
-      (d) => d?.suitability?.install?.usable && d?.suitability?.install?.sizeOK,
-    );
-    this._bootMediaDisk = this._allDisks.find((d) => d.bootMedia);
+    this._installDisks = await getInstallDisks();
     this._inflight_disks = false;
     this._disks_fetched = true;
   }


### PR DESCRIPTION
### Clearer install target choices in recovery

The installer now asks the backend for a filtered install-target list instead of working out its own choices from the full disk list. This avoids showing disks that should not be install targets.

| Before | After |
| -------- | -------- |
| <img width="523" height="687" alt="Screenshot 2026-05-15 at 9 33 29 am" src="https://github.com/user-attachments/assets/93b39d47-f7b9-4d47-b567-7e18555882a1" />  | <img width="526" height="493" alt="Screenshot 2026-05-15 at 9 25 46 am" src="https://github.com/user-attachments/assets/88b90a8a-4afa-4a2c-866e-e48ae83f7086" />   |

### New features

* Uses the backend-filtered install disk list in the recovery installer
* Keeps install target selection aligned with backend validation rules
* Expands disk mocks to cover boot media, tiny disks, and valid install targets

**Backend PR** - [Dogebox-WG/dogeboxd#223](https://github.com/Dogebox-WG/dogeboxd/pull/223)
