### PR TITLE
Wired Network Name Simplification - Frontend

### DIFF
--- a/src/api/network/get-networks.mocks.js
+++ b/src/api/network/get-networks.mocks.js
@@ -5,8 +5,8 @@ export const getResponse = {
   res: {
     success: true,
     networks: [
-      { type: "ethernet", interface: "eth0" },
-      { type: "ethernet", interface: "eth1" },
+      { type: "ethernet", interface: "eth0", active: true },
+      { type: "ethernet", interface: "eth1", active: false },
       {
         type: "wifi",
         interface: "wlan0",

--- a/src/components/common/dynamic-form/renders/fields/select.js
+++ b/src/components/common/dynamic-form/renders/fields/select.js
@@ -22,20 +22,7 @@ export function _render_select(field, options) {
       >
       ${options.labelEl}
       ${field.options.map(option => html`
-        <sl-option value=${option.value}>
-          ${option.tooltip
-            ? html`
-                <sl-tooltip
-                  content=${option.tooltip}
-                  hoist
-                  placement="top"
-                  style="--sl-z-index-tooltip: 1100;"
-                >
-                  <span>${option.label}</span>
-                </sl-tooltip>
-              `
-            : option.label}
-        </sl-option>
+        <sl-option value=${option.value}>${option.label}</sl-option>
       `)}
     </sl-select>
   `;

--- a/src/components/common/dynamic-form/renders/fields/select.js
+++ b/src/components/common/dynamic-form/renders/fields/select.js
@@ -22,7 +22,20 @@ export function _render_select(field, options) {
       >
       ${options.labelEl}
       ${field.options.map(option => html`
-        <sl-option value=${option.value}>${option.label}</sl-option>
+        <sl-option value=${option.value}>
+          ${option.tooltip
+            ? html`
+                <sl-tooltip
+                  content=${option.tooltip}
+                  hoist
+                  placement="top"
+                  style="--sl-z-index-tooltip: 1100;"
+                >
+                  <span>${option.label}</span>
+                </sl-tooltip>
+              `
+            : option.label}
+        </sl-option>
       `)}
     </sl-select>
   `;

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -175,16 +175,13 @@ class SelectNetwork extends LitElement {
 
     networks.forEach((network) => {
       if (network.type === "ethernet") {
-        const mappedLabel =
-          typeof network.label === "string" ? network.label.trim() : "";
-        let ethernetName = mappedLabel
-          ? `${mappedLabel} - ${network.interface}`
-          : `Ethernet - ${network.interface}`;
+        let ethernetName = "Wired Connection";
         if (network.active) ethernetName += " (connected)";
 
         return this._networks.push({
           ...network,
           label: ethernetName,
+          tooltip: network.interface,
           value: network.interface,
         });
       }

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -175,13 +175,12 @@ class SelectNetwork extends LitElement {
 
     networks.forEach((network) => {
       if (network.type === "ethernet") {
-        let ethernetName = "Wired Connection";
+        let ethernetName = `Ethernet - ${network.interface}`;
         if (network.active) ethernetName += " (connected)";
 
         return this._networks.push({
           ...network,
           label: ethernetName,
-          tooltip: network.interface,
           value: network.interface,
         });
       }


### PR DESCRIPTION
### Clearer wired network names

Wired network setup now shows each ethernet option with its actual device name while still indicating when the device is connected.

### New features

* Shows wired networks as `Ethernet - <device name>` in the setup flow
* Keeps the `(connected)` suffix so active links are easy to spot

So for eg, on the T6 at present, you'll see something like:

`Ethernet - enP4p65s0 (connected)`
`Ethernet - enP2p33s0`

**Backend PR** - [Dogebox-WG/dogeboxd#224](https://github.com/Dogebox-WG/dogeboxd/pull/224)
