### PR TITLE
Copy button visibility and seed phrase selection

### DIFF
--- a/src/components/common/clipboard/clipboard-utils.test.js
+++ b/src/components/common/clipboard/clipboard-utils.test.js
@@ -1,0 +1,40 @@
+import { expect } from "../../../../dev/node_modules/@open-wc/testing";
+
+import { canCopyToClipboard } from "/utils/clipboard.js";
+
+describe("canCopyToClipboard", () => {
+  it("returns true in a secure context with clipboard support", () => {
+    const fakeWindow = {
+      isSecureContext: true,
+      navigator: {
+        clipboard: {
+          writeText() {},
+        },
+      },
+    };
+
+    expect(canCopyToClipboard(fakeWindow)).to.equal(true);
+  });
+
+  it("returns false outside a secure context", () => {
+    const fakeWindow = {
+      isSecureContext: false,
+      navigator: {
+        clipboard: {
+          writeText() {},
+        },
+      },
+    };
+
+    expect(canCopyToClipboard(fakeWindow)).to.equal(false);
+  });
+
+  it("returns false when the clipboard API is unavailable", () => {
+    const fakeWindow = {
+      isSecureContext: true,
+      navigator: {},
+    };
+
+    expect(canCopyToClipboard(fakeWindow)).to.equal(false);
+  });
+});

--- a/src/components/views/action-create-key/index.js
+++ b/src/components/views/action-create-key/index.js
@@ -12,6 +12,7 @@ import { getMockList } from "/api/keys/get-keylist.mocks.js";
 
 // Utils
 import { asyncTimeout } from "/utils/timeout.js";
+import { canCopyToClipboard } from "/utils/clipboard.js";
 import { createAlert } from "/components/common/alert.js";
 
 // Styles
@@ -43,7 +44,7 @@ class CreateKey extends LitElement {
       _keyReady: { type: Boolean },
       _revealPhrase: { type: Boolean },
       _termsChecked: { type: Boolean },
-      _phrase: { type: String },
+      _phrase: { type: Array },
       onSuccess: { type: Object },
     };
   }
@@ -57,7 +58,7 @@ class CreateKey extends LitElement {
     this._form = null;
     this._keyList = [];
     this._keyListLoading = false;
-    this._phrase = "";
+    this._phrase = [];
     this.onSuccess = null;
     this.showSuccessAlert = false;
     this.label = "Create your key";
@@ -153,10 +154,6 @@ class CreateKey extends LitElement {
     this._revealPhrase = true;
   }
 
-  handleCopyButtonClick() {
-    this.shadowRoot.querySelector("#PhraseCopyBtn").click();
-  }
-
   handlePhraseCloseClick() {
     const dialog = this.shadowRoot.querySelector("#KeyGenDialog");
     this._revealPhrase = false;
@@ -177,7 +174,10 @@ class CreateKey extends LitElement {
   render() {
     const emptyPhrase =
       "one two three four five six seven eight nine ten eleven twelve".split(" ");
-    const phrase = this._phrase || [];
+    const phrase = Array.isArray(this._phrase) ? this._phrase : [];
+    const canCopy = canCopyToClipboard();
+    const canCopyPhrase = canCopy && this._revealPhrase && phrase.length > 0;
+    const phraseCopyValue = phrase.join(" ");
 
     const phraseGridClasses = classMap({
       "phrase-grid": true,
@@ -225,12 +225,15 @@ class CreateKey extends LitElement {
           <sl-icon name="eye-slash"></sl-icon>
         </sl-button>
 
-        <sl-button variant="text">
-          <sl-copy-button id="PhraseCopyBtn" value=${this._phrase}
-            ><span slot="copy-icon"
-              >Copy to clipboard &nbsp;<sl-icon name="copy"></sl-icon></span
-          ></sl-copy-button>
-        </sl-button>
+        ${canCopyPhrase
+          ? html`
+              <sl-copy-button id="PhraseCopyBtn" value=${phraseCopyValue}>
+                <span slot="copy-icon">
+                  Copy to clipboard &nbsp;<sl-icon name="copy"></sl-icon>
+                </span>
+              </sl-copy-button>
+            `
+          : nothing}
       </div>
 
       <div class="phraseFooter">

--- a/src/components/views/action-create-key/styles.js
+++ b/src/components/views/action-create-key/styles.js
@@ -88,10 +88,17 @@ export const createKeyStyles = css`
     justify-content: center;
   }
 
+  .phrase-grid:not(.blur) sl-tag::part(base) {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
   .phrase-grid sl-tag span.order {
     color: var(--sl-color-neutral-400);
     position: absolute;
     left: 1rem;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   .phrase-grid.blur sl-tag span.term {

--- a/src/components/views/action-remote-access/index.js
+++ b/src/components/views/action-remote-access/index.js
@@ -14,6 +14,7 @@ import {
 } from "/api/sshkeys/sshkeys.js";
 import "/components/common/action-row/action-row.js";
 import { asyncTimeout } from "/utils/timeout.js";
+import { canCopyToClipboard } from "/utils/clipboard.js";
 import { createAlert } from "/components/common/alert.js";
 
 export class RemoteAccessSettings extends LitElement {
@@ -219,6 +220,7 @@ export class RemoteAccessSettings extends LitElement {
   render() {
     const hasKeys = this._ssh_public_keys.length
     const keys = this._ssh_public_keys 
+    const canCopy = canCopyToClipboard();
     return html`
       <h1>Remote Access</h1>
 
@@ -267,7 +269,9 @@ export class RemoteAccessSettings extends LitElement {
           <div slot="hidden">
             <div class="key-reveal-dropdown">${k.key}</div>
             <div class="key-actions">
-              <sl-copy-button hoist value=${k.key}></sl-copy-button>
+              ${canCopy
+                ? html`<sl-copy-button hoist value=${k.key}></sl-copy-button>`
+                : nothing}
               <sl-icon-button name="trash-fill" label="Trash" @click=${() => this.handleTrash(k.id)}></sl-icon-button>
             </div>
           </div>

--- a/src/components/views/service-status-card/index.js
+++ b/src/components/views/service-status-card/index.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css, nothing } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
+import { canCopyToClipboard } from '/utils/clipboard.js';
 
 /**
  * Service status card component for displaying external service information
@@ -18,6 +19,7 @@ class ServiceStatusCard extends LitElement {
 
   renderTailscaleContent() {
     const status = this.service?.status || {};
+    const canCopy = canCopyToClipboard();
 
     return html`
       <div class="service-details">
@@ -25,7 +27,7 @@ class ServiceStatusCard extends LitElement {
           <span class="detail-label">IP Address</span>
           <span class="detail-value">
             ${status.ip || 'Not available'}
-            ${status.ip ? html`
+            ${status.ip && canCopy ? html`
               <sl-copy-button value="${status.ip}" class="copy-btn"></sl-copy-button>
             ` : nothing}
           </span>

--- a/src/components/views/x-metric/metric.js
+++ b/src/components/views/x-metric/metric.js
@@ -1,5 +1,6 @@
 import { LitElement, html, css, choose } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import "/components/common/sparkline-chart/sparkline-chart-v2.js";
+import { canCopyToClipboard } from '/utils/clipboard.js';
 
 class MetricView extends LitElement {
   static properties = {
@@ -27,13 +28,18 @@ class MetricView extends LitElement {
     const type = this.metric.type || null;
     const desc = (this.metric.description ?? '').trim();
     const tip = desc || String(this.metric.label || this.metric.name || '');
+    const canCopy = canCopyToClipboard();
 
     return html`
-      <sl-copy-button
-        class="copy"
-        value="${this.metric.values}"
-        @click=${(e) => e.stopPropagation()}>
-      </sl-copy-button>
+      ${canCopy
+        ? html`
+            <sl-copy-button
+              class="copy"
+              value="${this.metric.values}"
+              @click=${(e) => e.stopPropagation()}>
+            </sl-copy-button>
+          `
+        : ''}
 
       <div class="value-container">
         ${choose(type, [

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,8 @@
+export function canCopyToClipboard(win = window) {
+  if (!win || !win.isSecureContext) {
+    return false;
+  }
+
+  const clipboard = win.navigator?.clipboard;
+  return typeof clipboard?.writeText === "function";
+}


### PR DESCRIPTION
- Adds copy button visibility logic, used to hide copy button when outside of a secure context or the copy function isn't available
- Updates CSS to allow neat manual selection of seed phrase for manual copy.

css updated allow neat selection of seed phrase words only
<img width="945" height="910" alt="Screenshot 2026-05-22 at 12 08 59 pm" src="https://github.com/user-attachments/assets/ca5d00fa-7323-47ae-b655-04990c221cd3" />
