### PR TITLE
Pagination UI improvements

### DIFF
--- a/src/pages/page-pup-library/index.js
+++ b/src/pages/page-pup-library/index.js
@@ -144,6 +144,8 @@ class LibraryView extends LitElement {
     }
 
     const SKELS = Array.from({ length: 1 })
+    const totalPages = this.installedList.data ? Math.max(this.installedList.getTotalPages(), 1) : 1;
+    const paginationDisabled = this.busy || this.fetchLoading || this.fetchError || !this.installedList.data;
 
     return html`
       <div class="padded">
@@ -152,12 +154,25 @@ class LibraryView extends LitElement {
         ` : this.renderSectionInstalledBody(ready, SKELS, hasItems) }
       </div>
 
+      <div class="pagination-dock">
+        <paginator-ui
+          ?disabled=${paginationDisabled}
+          @go-next=${this.installedList.nextPage}
+          @go-prev=${this.installedList.previousPage}
+          currentPage=${this.installedList.currentPage}
+          totalPages=${totalPages}
+        ></paginator-ui>
+      </div>
+
     `;
   }
 
   static styles = css`
     :host {
+      --pagination-dock-height: 72px;
+      box-sizing: border-box;
       display: block;
+      padding-bottom: var(--pagination-dock-height);
       width: 100%;
       overflow-x: hidden;
     }
@@ -165,6 +180,26 @@ class LibraryView extends LitElement {
     .padded {
       background: #23252a;
       margin: 1em;
+    }
+
+    .pagination-dock {
+      position: fixed;
+      left: var(--page-margin-left);
+      right: 0;
+      bottom: 0;
+      z-index: 90;
+      height: var(--pagination-dock-height);
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      box-sizing: border-box;
+      padding: 0 20px;
+      background: #23252a;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .pagination-dock paginator-ui {
+      width: 100%;
     }
 
     .banner {

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -81,14 +81,6 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
       </div>
       <style>${pupCardGrid}</style>
 
-      <paginator-ui
-        ?disabled=${this.busy}
-        @go-next=${this.installedList.nextPage}
-        @go-prev=${this.installedList.previousPage}
-        currentPage=${this.installedList.currentPage}
-        totalPages=${this.installedList.getTotalPages()}
-      ></paginator-ui>
-
       `: nothing
     }
   `

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -208,6 +208,8 @@ class StoreView extends LitElement {
     }
 
     const SKELS = Array.from({ length: 1 })
+    const totalPages = this.packageList.data ? Math.max(this.packageList.getTotalPages(), 1) : 1;
+    const paginationDisabled = this.busy || this.fetchLoading || this.fetchError || !this.packageList.data;
 
     return html`
       <page-banner title="Pup Store" subtitle="Dogebox">
@@ -241,6 +243,16 @@ class StoreView extends LitElement {
         : this.renderSectionBody(ready, SKELS, hasItems)
       }
 
+      <div class="pagination-dock">
+        <paginator-ui
+          ?disabled=${paginationDisabled}
+          @go-next=${this.packageList.nextPage}
+          @go-prev=${this.packageList.previousPage}
+          currentPage=${this.packageList.currentPage}
+          totalPages=${totalPages}
+        ></paginator-ui>
+      </div>
+
       ${this._showSourceManagementDialog ? html`
         <action-manage-sources></action-manage-sources>
       ` : nothing }
@@ -250,8 +262,10 @@ class StoreView extends LitElement {
 
   static styles = css`
     :host {
+      --pagination-dock-height: 72px;
+      box-sizing: border-box;
       display: block;
-      padding: 20px;
+      padding: 20px 20px calc(20px + var(--pagination-dock-height));
     }
 
     div.row {
@@ -298,6 +312,26 @@ class StoreView extends LitElement {
       padding: var(--sl-spacing-x-large) var(--sl-spacing-medium);
       font-family: 'Comic Neue', sans-serif;
       text-align: center;
+    }
+
+    .pagination-dock {
+      position: fixed;
+      left: var(--page-margin-left);
+      right: 0;
+      bottom: 0;
+      z-index: 90;
+      height: var(--pagination-dock-height);
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      box-sizing: border-box;
+      padding: 0 20px;
+      background: #23252a;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .pagination-dock paginator-ui {
+      width: 100%;
     }
 
     .slogan-wrap {

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -74,14 +74,6 @@ export function renderSectionBody(ready, SKELS, hasItems) {
       </div>
       <style>${pupCardGrid}</style>
 
-      <paginator-ui
-        ?disabled=${this.busy}
-        @go-next=${this.packageList.nextPage}
-        @go-prev=${this.packageList.previousPage}
-        currentPage=${this.packageList.currentPage}
-        totalPages=${this.packageList.getTotalPages()}
-      ></paginator-ui>
-
       `: nothing
     }
   `

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,4 @@
 html {
-  background: #23252a;
   overflow-y: scroll;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,8 @@
+html {
+  background: #23252a;
+  overflow-y: scroll;
+}
+
 body {
   background: #23252a;
   font: 16px var(--sl-font-sans);


### PR DESCRIPTION
Move the pup store and library pagination controls into a dock at the bottom of the screen. 
Also reserve vertical scrollbar space globally so centred content doesn't shift when switching to pages without a scroll bar.

### Changes

- Move pup store and library pagination controls out of the list and into fixed docks
- Render pagination immediately during loading, rather than waiting. Use disabled controls while loading and fallback to `Page 1 of 1`
- Add bottom padding on affected pages so list content can't hide underneath the dock
- Keep page widths stabl  by forcing the document scrollbar gutter
- 
### Screenshots
<img width="1800" height="1033" alt="Screenshot 2026-05-22 at 3 45 37 pm" src="https://github.com/user-attachments/assets/39f95c72-242d-4073-8a89-5b5a6c190784" />

<img width="1800" height="1033" alt="Screenshot 2026-05-22 at 3 45 45 pm" src="https://github.com/user-attachments/assets/d7693bef-2201-4bfe-9b03-ef57594e0e96" />

<img width="1800" height="1026" alt="Screenshot 2026-05-22 at 3 45 53 pm" src="https://github.com/user-attachments/assets/5f94556b-0ae7-4a52-9e60-da2b8c593382" />
