### PR TITLE
Implement canCopyToClipboard for pup source copy button

### DIFF
--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -31,6 +31,7 @@ import { renderDialog } from "./renders/dialog.js";
 import { renderActions } from "./renders/actions.js";
 import { renderStatus } from "./renders/status.js";
 import { addSidebarPup, removeSidebarPup } from "/api/system/sidebar-preferences.js";
+import { canCopyToClipboard } from "/utils/clipboard.js";
 
 class PupPage extends LitElement {
   static get properties() {
@@ -497,6 +498,7 @@ class PupPage extends LitElement {
     const source = pkg?.state?.source || pkg?.def?.source || null;
     const sourceLocation = source?.location?.trim();
     const isWebSource = /^https?:\/\//i.test(sourceLocation || "");
+    const canCopy = canCopyToClipboard();
 
     const renderMenu = () => html`
       <action-row prefix="power" name="state" label="Enabled" ?disabled=${disableActions}>
@@ -558,7 +560,7 @@ class PupPage extends LitElement {
           target=${isWebSource ? "_blank" : "_self"}
         >
           <span title=${sourceLocation}>${sourceLocation}</span>
-          ${!isWebSource ? html`
+          ${!isWebSource && canCopy ? html`
             <sl-copy-button
               slot="suffix"
               value=${sourceLocation}

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -14,6 +14,7 @@ import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 import { pkgController } from "/controllers/package/index.js";
 import { asyncTimeout } from "/utils/timeout.js";
+import { canCopyToClipboard } from "/utils/clipboard.js";
 import "/components/common/action-row/action-row.js";
 import "/components/common/reveal-row/reveal-row.js";
 import "/components/common/page-container.js";
@@ -153,6 +154,7 @@ class PupInstallPage extends LitElement {
     const source = pkg?.def?.source || pkg?.state?.source || null;
     const sourceLocation = source?.location?.trim();
     const isWebSource = /^https?:\/\//i.test(sourceLocation || "");
+    const canCopy = canCopyToClipboard();
     const popover_page = path[1];
 
     const wrapperClasses = classMap({
@@ -288,7 +290,7 @@ class PupInstallPage extends LitElement {
                 target=${isWebSource ? "_blank" : "_self"}
               >
                 <span title=${sourceLocation}>${sourceLocation}</span>
-                ${!isWebSource ? html`
+                ${!isWebSource && canCopy ? html`
                   <sl-copy-button
                     slot="suffix"
                     value=${sourceLocation}


### PR DESCRIPTION
Makes use of https://github.com/Dogebox-WG/dpanel/pull/255 as this wasn't merged in when the pup source row was added