### PR TITLE
Pup card layout fix

### DIFF
--- a/src/components/views/card-pup-install/index.js
+++ b/src/components/views/card-pup-install/index.js
@@ -155,7 +155,7 @@ class PupInstallCard extends LitElement {
   static styles = css`
     :host {
       --icon-size: 72px;
-      --row-height: 114px;
+      --row-height: 133px;
     }
 
     a, button {
@@ -176,7 +176,7 @@ class PupInstallCard extends LitElement {
       position: relative;
       display: flex;
       flex-direction: row;
-      margin-bottom: 1em;
+      margin-bottom: 0em;
       width: 100%;
       padding: 1em;
       box-sizing: border-box;

--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -105,7 +105,7 @@
     static styles = css`
       :host {
         --icon-size: 72px;
-        --row-height: 114px;
+        --row-height: 133px;
       }
 
       a, button {
@@ -121,7 +121,7 @@
       .pup-card-wrap {
         display: flex;
         flex-direction: row;
-        margin-bottom: 1em;
+        margin-bottom: 0em;
         width: 100%;
         padding: 1em;
         box-sizing: border-box;


### PR DESCRIPTION
increase pup card height and reduce bottom margin to allow more space for tags and pills.

**Before** - Pill overflows divider line when a tag is also present
<img width="1204" height="1093" alt="image" src="https://github.com/user-attachments/assets/1293f4e0-fc85-4d40-826b-7dcbaf2ad07b" />


**After** - Pill no longer overflows divider line when a tag is also present
<img width="1773" height="1025" alt="Screenshot 2026-07-06 at 1 10 10 pm" src="https://github.com/user-attachments/assets/db6fac96-58ed-46f9-9a92-da07e4e4f61b" />
