### PR TITLE
Fix vertical alignment and text wrapping

### DIFF
--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -317,20 +317,22 @@ class StoreView extends LitElement {
           </sl-input>
           <div class="search-options">
             <span class="search-options-label">Also search:</span>
-            <sl-checkbox
-              size="small"
-              data-option="description"
-              ?checked=${this.searchInDescription}
-              @sl-change=${this.handleSearchOptionChange}>
-              Descriptions
-            </sl-checkbox>
-            <sl-checkbox
-              size="small"
-              data-option="interfaces"
-              ?checked=${this.searchInInterfaces}
-              @sl-change=${this.handleSearchOptionChange}>
-              Interfaces Provided
-            </sl-checkbox>
+            <div class="search-options-checks">
+              <sl-checkbox
+                size="small"
+                data-option="description"
+                ?checked=${this.searchInDescription}
+                @sl-change=${this.handleSearchOptionChange}>
+                Descriptions
+              </sl-checkbox>
+              <sl-checkbox
+                size="small"
+                data-option="interfaces"
+                ?checked=${this.searchInInterfaces}
+                @sl-change=${this.handleSearchOptionChange}>
+                Interfaces Provided
+              </sl-checkbox>
+            </div>
           </div>
         </div>
       </div>
@@ -401,15 +403,24 @@ class StoreView extends LitElement {
       flex-wrap: wrap;
       align-items: center;
       gap: 1em;
+      line-height: 0;
       margin-top: 0.6em;
       padding-left: 0.25em;
     }
 
+    .search-options-checks {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5em;
+    }
+
     .search-options-label {
-      font-size: 0.75rem;
       text-transform: uppercase;
       font-weight: bold;
       color: var(--sl-color-neutral-500);
+      padding-left: 0.25em;
     }
 
     .tab-wrap {


### PR DESCRIPTION
Aligns items under the search bar and makes them wrap in a sensible way.
<img width="644" height="290" alt="Screenshot 2026-07-15 180711" src="https://github.com/user-attachments/assets/f763c2b9-9232-4e9e-83d6-bf56c1e295f6" />
<img width="491" height="288" alt="Screenshot 2026-07-15 180647" src="https://github.com/user-attachments/assets/aebfe53f-3250-40fd-b245-ffb3f27dbe97" />
<img width="472" height="297" alt="Screenshot 2026-07-15 180745" src="https://github.com/user-attachments/assets/127ff7a7-f6ea-41a0-8f4e-4991b8948037" />
<img width="293" height="304" alt="Screenshot 2026-07-15 180810" src="https://github.com/user-attachments/assets/ad4c7394-8e09-45d0-b239-559ee026b388" />
