### PR TITLE
Safely narrow response hook payloads

### DIFF
--- a/src/api/bootstrap/bootstrap.ts
+++ b/src/api/bootstrap/bootstrap.ts
@@ -24,10 +24,22 @@ interface VersionPayload {
   version: Record<string, unknown>;
 }
 
+function isVersionPayload(payload: unknown): payload is VersionPayload {
+  if (typeof payload !== "object" || payload === null || !("version" in payload)) {
+    return false;
+  }
+
+  return typeof payload.version === "object" && payload.version !== null;
+}
+
 // Response hooks
 const bumpVersionHook: ResponseHook = {
-  'bump-version': (payload: VersionPayload) => {
-      payload.version.release = "v.9000"
-    return payload
+  'bump-version': (payload: unknown) => {
+    if (!isVersionPayload(payload)) {
+      return payload;
+    }
+
+    payload.version.release = "v.9000";
+    return payload;
   }
 }


### PR DESCRIPTION
Small fix addressing an issue caused by https://github.com/Dogebox-WG/dpanel/pull/277/changes/3966d8d0fbfdfdb56784f747f16c652107348f38

```
src/api/bootstrap/bootstrap.ts:29:3 - error TS2322: Type '(payload: VersionPayload) => VersionPayload' is not assignable to type '(data: unknown) => unknown'.
  Types of parameters 'payload' and 'data' are incompatible.
    Type 'unknown' is not assignable to type 'VersionPayload'.

29   'bump-version': (payload: VersionPayload) => {
     ~~~~~~~~~~~~~~


Found 1 error in src/api/bootstrap/bootstrap.ts:29

make: *** [Makefile:35: dpanel-build] Error 2
```

It now updates the mock version only when the response contains a valid version object.
Otherwise, the response payload is returned unchanged.