### PR TITLE
System update modal failure handling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
           name = "dpanel";
           src = ./.;
 
-          npmDepsHash = "sha256-8u5TAf4uE+twwR0/F9NxB6PDbv55ngmSLTWXxHy3iO8=";
+          npmDepsHash = "sha256-Ud6fUHy+Edfkcb3syp3iSVBLWGodxHDl6WbMxxj0iD0=";
 
           nativeBuildInputs = [ pkgs.protobuf ];
 

--- a/src/components/views/action-check-updates.test.js
+++ b/src/components/views/action-check-updates.test.js
@@ -1,0 +1,67 @@
+import {
+  html,
+  fixture,
+  expect,
+  waitUntil,
+} from "../../../dev/node_modules/@open-wc/testing";
+
+import { store } from "/state/store.js";
+
+import "./action-check-updates/index.js";
+
+describe("CheckUpdatesView", () => {
+  let originalNetworkContext;
+
+  beforeEach(() => {
+    originalNetworkContext = { ...store.networkContext };
+    store.updateState({
+      networkContext: {
+        useMocks: true,
+        forceFailures: true,
+        "mock::updates::/system/updates::get": true,
+      },
+    });
+  });
+
+  afterEach(() => {
+    store.updateState({ networkContext: originalNetworkContext });
+  });
+
+  it("shows a retryable failure and recovers when checking again", async () => {
+    const el = await fixture(
+      html`<x-action-check-updates></x-action-check-updates>`,
+    );
+
+    await waitUntil(
+      () => !el._inflight_checking && el._check_error,
+      "update check did not enter its failure state",
+    );
+    await el.updateComplete;
+
+    const failureAlert = el.shadowRoot.querySelector('sl-alert[variant="danger"]');
+    const retryButton = [...el.shadowRoot.querySelectorAll("sl-button")]
+      .find((button) => button.textContent.trim() === "Check again");
+
+    expect(failureAlert).to.exist;
+    expect(failureAlert.textContent).to.contain("Check failed");
+    expect(el.shadowRoot.textContent).to.contain(
+      "Unable to check for updates. Please try again.",
+    );
+    expect(retryButton).to.exist;
+    expect(retryButton.hasAttribute("disabled")).to.equal(false);
+
+    store.updateState({ networkContext: { forceFailures: false } });
+    retryButton.click();
+
+    await waitUntil(
+      () => !el._inflight_checking && el._has_updates,
+      "update check did not recover after retrying",
+      { timeout: 2000 },
+    );
+    await el.updateComplete;
+
+    expect(el._check_error).to.equal(false);
+    expect(el.shadowRoot.textContent).to.contain("Update available");
+    expect(el.shadowRoot.querySelector('sl-alert[variant="danger"]')).not.to.exist;
+  });
+});

--- a/src/components/views/action-check-updates.test.js
+++ b/src/components/views/action-check-updates.test.js
@@ -45,7 +45,7 @@ describe("CheckUpdatesView", () => {
     expect(failureAlert).to.exist;
     expect(failureAlert.textContent).to.contain("Check failed");
     expect(el.shadowRoot.textContent).to.contain(
-      "Unable to check for updates. Please try again.",
+      "Unable to check for updates: Simulated error returned from /system/updates",
     );
     expect(retryButton).to.exist;
     expect(retryButton.hasAttribute("disabled")).to.equal(false);
@@ -60,7 +60,7 @@ describe("CheckUpdatesView", () => {
     );
     await el.updateComplete;
 
-    expect(el._check_error).to.equal(false);
+    expect(el._check_error).to.equal(null);
     expect(el.shadowRoot.textContent).to.contain("Update available");
     expect(el.shadowRoot.querySelector('sl-alert[variant="danger"]')).not.to.exist;
   });

--- a/src/components/views/action-check-updates/index.ts
+++ b/src/components/views/action-check-updates/index.ts
@@ -48,7 +48,7 @@ export class CheckUpdatesView extends LitElement {
   declare _updates: unknown[];
   declare _has_updates: boolean;
   declare _inflight_checking: boolean;
-  declare _check_error: boolean;
+  declare _check_error: string | null;
   declare _confirmation_checked: boolean;
   declare _inflight_update: boolean;
   declare _update_commenced: boolean;
@@ -71,7 +71,7 @@ export class CheckUpdatesView extends LitElement {
       _updates: { type: Array },
       _has_updates: { type: Boolean },
       _inflight_checking: { type: Boolean },
-      _check_error: { type: Boolean },
+      _check_error: { type: String },
       _confirmation_checked: { type: Boolean },
       _inflight_update: { type: Boolean},
       _update_commenced: { type: Boolean },
@@ -93,7 +93,7 @@ export class CheckUpdatesView extends LitElement {
     this._updates = [];
     this._has_updates = false;
     this._inflight_checking = false;
-    this._check_error = false;
+    this._check_error = null;
     this._systemJobId = "";
     this._updatePollId = null;
   }
@@ -125,7 +125,7 @@ export class CheckUpdatesView extends LitElement {
     this._updates = [];
     this._updatablePackages = [];
     this._has_updates = false;
-    this._check_error = false;
+    this._check_error = null;
     this._inflight_checking = true;
 
     try {
@@ -146,7 +146,9 @@ export class CheckUpdatesView extends LitElement {
       this._has_updates = this._updatablePackages.length > 0;
     } catch (error) {
       console.error("Failed to check for system updates:", error);
-      this._check_error = true;
+      this._check_error = error instanceof Error
+        ? error.message
+        : String(error);
     } finally {
       this._inflight_checking = false;
     }
@@ -333,7 +335,7 @@ export class CheckUpdatesView extends LitElement {
         </sl-alert>
 
         <p style="line-height: 1.1; color: #777">
-          <small>Unable to check for updates. Please try again.</small>
+          <small>Unable to check for updates: ${this._check_error}</small>
           <sl-button size="small" variant="text" @click=${this.fetchUpdates}>Check again</sl-button>
         </p>
         `: nothing}

--- a/src/components/views/action-check-updates/index.ts
+++ b/src/components/views/action-check-updates/index.ts
@@ -48,6 +48,7 @@ export class CheckUpdatesView extends LitElement {
   declare _updates: unknown[];
   declare _has_updates: boolean;
   declare _inflight_checking: boolean;
+  declare _check_error: boolean;
   declare _confirmation_checked: boolean;
   declare _inflight_update: boolean;
   declare _update_commenced: boolean;
@@ -70,6 +71,7 @@ export class CheckUpdatesView extends LitElement {
       _updates: { type: Array },
       _has_updates: { type: Boolean },
       _inflight_checking: { type: Boolean },
+      _check_error: { type: Boolean },
       _confirmation_checked: { type: Boolean },
       _inflight_update: { type: Boolean},
       _update_commenced: { type: Boolean },
@@ -89,6 +91,9 @@ export class CheckUpdatesView extends LitElement {
     this._page = PAGE_ONE;
     this._logs = [];
     this._updates = [];
+    this._has_updates = false;
+    this._inflight_checking = false;
+    this._check_error = false;
     this._systemJobId = "";
     this._updatePollId = null;
   }
@@ -118,25 +123,33 @@ export class CheckUpdatesView extends LitElement {
   async fetchUpdates() {
     // Reset
     this._updates = [];
+    this._updatablePackages = [];
+    this._has_updates = false;
+    this._check_error = false;
     this._inflight_checking = true;
 
-    // Fetch
-    const updateResponse = await checkForUpdates();
+    try {
+      // Fetch
+      const updateResponse = await checkForUpdates();
 
-    // Find any packages that have updates
-    const updatablePackages: ResolvedUpdatablePackage[] = Object.keys(updateResponse.packages).filter(pkg => {
-      return updateResponse.packages[pkg].latestUpdate !== updateResponse.packages[pkg].currentVersion
-    }).map(pkg => ({
-      ...updateResponse.packages[pkg],
-      latestUpdate: updateResponse.packages[pkg].updates.find((update) => update.version === updateResponse.packages[pkg].latestUpdate)
-    }))
+      // Find any packages that have updates
+      this._updatablePackages = Object.keys(updateResponse.packages).filter(pkg => {
+        return updateResponse.packages[pkg].latestUpdate !== updateResponse.packages[pkg].currentVersion
+      }).map(pkg => ({
+        ...updateResponse.packages[pkg],
+        latestUpdate: updateResponse.packages[pkg].updates.find((update) => update.version === updateResponse.packages[pkg].latestUpdate)
+      }));
 
-    this._updatablePackages = updatablePackages || [];
-    await asyncTimeout(1000);
+      await asyncTimeout(1000);
 
-    // Toggle UI according to whether there are updates or not.
-    this._has_updates = this._updatablePackages.length > 0;
-    this._inflight_checking = false;
+      // Toggle UI according to whether there are updates or not.
+      this._has_updates = this._updatablePackages.length > 0;
+    } catch (error) {
+      console.error("Failed to check for system updates:", error);
+      this._check_error = true;
+    } finally {
+      this._inflight_checking = false;
+    }
   }
 
   handleReviewUpdates() {
@@ -313,7 +326,19 @@ export class CheckUpdatesView extends LitElement {
         </p>
         `: nothing}
 
-        ${!this._inflight_checking && !this._has_updates ? html`
+        ${!this._inflight_checking && this._check_error ? html`
+        <sl-alert open variant="danger" style="text-align: left">
+          <small style="display:inline-block; margin-bottom: 4px;">Check failed</small>
+          <sl-progress-bar value="100" style="--indicator-color: var(--sl-color-danger-600)"></sl-progress-bar>
+        </sl-alert>
+
+        <p style="line-height: 1.1; color: #777">
+          <small>Unable to check for updates. Please try again.</small>
+          <sl-button size="small" variant="text" @click=${this.fetchUpdates}>Check again</sl-button>
+        </p>
+        `: nothing}
+
+        ${!this._inflight_checking && !this._check_error && !this._has_updates ? html`
         <sl-alert open variant="primary" style="text-align: left">
           <small style="display:inline-block; margin-bottom: 4px;">Check complete</small>
           <sl-progress-bar value="100"></sl-progress-bar>
@@ -325,7 +350,7 @@ export class CheckUpdatesView extends LitElement {
         </p>
         `: nothing}
 
-        ${!this._inflight_checking && this._has_updates ? html`
+        ${!this._inflight_checking && !this._check_error && this._has_updates ? html`
         <sl-alert open variant="primary" style="text-align: left">
           <small style="display:inline-block; margin-bottom: 4px;">Update available</small>
           <sl-progress-bar value="100"></sl-progress-bar>


### PR DESCRIPTION
### System Update checks handle failures

The System Updates modal now shows an error when an update check fails.

https://github.com/Dogebox-WG/dpanel/pull/284 Needs to be merged first as it was required to test this feature

### New features

* Shows a clear failure state instead of checking indefinitely
* Brief error description message
* Users can retry a failed update check

### Testing
Ctrl‑L → Dev Tools → Open Config → enable Network Mocks, enable → GET /system/updates, and enable Force Network Failures
Then run a system upgrade check

### UI
<img width="524" height="298" alt="Screenshot 2026-07-28 at 2 19 59 pm" src="https://github.com/user-attachments/assets/e12d18d7-c3bf-4e33-a30f-053e32b84a51" />
