### PR TITLE
Logout on session expiry

### DIFF
--- a/src/api/login/login.ts
+++ b/src/api/login/login.ts
@@ -3,6 +3,7 @@ import type { AuthenticateResponse } from "/gen/authenticate/v1/authenticate_pb.
 import { AuthenticateService } from "/gen/authenticate/v1/authenticate_pb.js";
 import { getTransport } from "/api/transport.js";
 import { store } from "/state/store.js";
+import { startSessionExpiry } from "/state/session-expiry.js";
 
 interface LoginRequest {
   password: string;
@@ -18,6 +19,7 @@ export async function postLogin(body: LoginRequest): Promise<AuthenticateRespons
     const res = await client.authenticate({ password: body.password });
     if (res.token) {
       store.updateState({ networkContext: { token: res.token } });
+      startSessionExpiry();
     }
     return res;
   } catch (err) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,10 @@ import { setRouterInstance } from "/router/index.js";
 import debounce from "/utils/debounce.js";
 import { bindToClass } from "/utils/class-bind.js";
 import { isUnauthedRoute, hasFlushParam } from "/utils/url-utils.js";
+import {
+  clearSessionExpiryTimer,
+  scheduleSessionExpiry,
+} from "/state/session-expiry.js";
 
 // Apis
 import { getBootstrapV2 } from "/api/bootstrap/bootstrap.js";
@@ -125,6 +129,8 @@ export class DPanelApp extends LitElement {
     // Initial check to set orientation on load
     this._handleResize();
 
+    scheduleSessionExpiry();
+
     // Instanciate a web socket connection and add app as an observer
     this.mainChannel.addObserver(this);
 
@@ -140,6 +146,7 @@ export class DPanelApp extends LitElement {
     this.removeEventListener("menu-toggle-request", this._handleMenuToggleRequest);
     this.mainChannel.removeObserver(this);
     jobWebSocket.disconnect();
+    clearSessionExpiryTimer();
     super.disconnectedCallback();
   }
 

--- a/src/router/middleware.ts
+++ b/src/router/middleware.ts
@@ -3,6 +3,7 @@ import { store } from "/state/store.js";
 import { pkgController } from "/controllers/package/index.js";
 import { getBootstrapV2 } from "/api/bootstrap/bootstrap.js";
 import { getStoreListing } from "/api/sources/sources.js";
+import { clearSessionExpiryTimer } from "/state/session-expiry.js";
 import type { RouteContext, RouteCommands } from "./router.js";
 
 export async function loadPup(context: RouteContext, commands: RouteCommands) {
@@ -80,7 +81,8 @@ export function isAuthed(context: RouteContext, commands: RouteCommands): undefi
 }
 
 export function performLogout(context: RouteContext, commands: RouteCommands): never {
-  store.updateState({ networkContext: { token: null } });
+  clearSessionExpiryTimer();
+  store.updateState({ networkContext: { token: null, sessionExpiresAt: null } });
   return commands.redirect("/login");
 }
 

--- a/src/state/session-expiry.ts
+++ b/src/state/session-expiry.ts
@@ -1,0 +1,32 @@
+import { store } from "/state/store.js";
+
+const SESSION_LIFETIME_MS = 60 * 60 * 1000;
+
+let expiryTimer: number | null = null;
+
+export function startSessionExpiry() {
+  const sessionExpiresAt = Date.now() + SESSION_LIFETIME_MS;
+  store.updateState({ networkContext: { sessionExpiresAt } });
+  scheduleSessionExpiry();
+}
+
+export function scheduleSessionExpiry() {
+  clearSessionExpiryTimer();
+
+  const { sessionExpiresAt } = store.networkContext;
+  if (!sessionExpiresAt) {
+    return;
+  }
+
+  const delay = Math.max(0, sessionExpiresAt - Date.now());
+  expiryTimer = window.setTimeout(() => {
+    window.location.replace(`${window.location.origin}/logout`);
+  }, delay);
+}
+
+export function clearSessionExpiryTimer() {
+  if (expiryTimer !== null) {
+    window.clearTimeout(expiryTimer);
+    expiryTimer = null;
+  }
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -35,6 +35,7 @@ export interface NetworkContext {
   reqLogs: boolean;
   status: string;
   token: string | false | null;
+  sessionExpiresAt?: number | null;
   demoSystemPrompt: string;
   logStatsUpdates: boolean;
   logStateUpdates: boolean;
@@ -177,6 +178,7 @@ class Store implements StoreState {
       reqLogs: false,
       status: "online",
       token: false,
+      sessionExpiresAt: null,
       demoSystemPrompt: "",
       logStatsUpdates: false,
       logStateUpdates: false,


### PR DESCRIPTION
Dpanel now automatically takes users to the logged-out screen when their token session has expires, without waiting for another API request.
(For now it's just using a 60 minute timer, may differ slightly from the backend but these can be aligned later in https://github.com/Dogebox-WG/dpanel/issues/289

### New features

* Redirect active and suspended browser sessions through the existing logout route at the one-hour deadline
* Restore the remaining timeout after a page reload and clear it during explicit logout