### PR TITLE
Show selected timezone when opening dropdown

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
           name = "dpanel";
           src = ./.;
 
-          npmDepsHash = "sha256-8u5TAf4uE+twwR0/F9NxB6PDbv55ngmSLTWXxHy3iO8=";
+          npmDepsHash = "sha256-9djGsnvcLu6mbP8MDN3FdH7Rtmw3HfB7p7H+kZDeptE=";
 
           nativeBuildInputs = [ pkgs.protobuf ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@bufbuild/protobuf": "^2.11.0",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-web": "^2.1.1",
-        "@deform-wg/deform": "1.0.0-rc.3",
+        "@deform-wg/deform": "1.0.0-rc.4",
         "@fnando/sparkline": "^0.3.10",
         "@fontsource/comic-neue": "^5.2.7",
         "@fontsource/montserrat": "^5.2.8",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@deform-wg/deform": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@deform-wg/deform/-/deform-1.0.0-rc.3.tgz",
-      "integrity": "sha512-ZOaVEG0znML0sk51k1hHWtadNXhuBAOG4BvPFWTabrQEi9fAROtFOAHPNNxM78u02UqJMTrcZZkh1EH04oLB2g==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@deform-wg/deform/-/deform-1.0.0-rc.4.tgz",
+      "integrity": "sha512-1AxTi3MEqfiuEKLKriexLr32pdRKXnM9B4rCkUIoJG4zEoDfEjGfrYuJGWGk2gFPKqtRRinI04y3m/tOkB0VCw==",
       "license": "MIT",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.20.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
-    "@deform-wg/deform": "1.0.0-rc.3",
+    "@deform-wg/deform": "1.0.0-rc.4",
     "@fnando/sparkline": "^0.3.10",
     "@fontsource/comic-neue": "^5.2.7",
     "@fontsource/montserrat": "^5.2.8",


### PR DESCRIPTION
The timezone picker now shows the configured timezone when opened, avoiding the need to search from the beginning of the list each time.
This was fixed by updating Deform to `1.0.0-rc.4`, which addressed the issue - [deform-wg/deform#15](https://github.com/deform-wg/deform/pull/15).

### New features

* Opens the searchable timezone picker at the existing selection
* Updates dPanel to Deform `1.0.0-rc.4` and updates the Nix dependency hash